### PR TITLE
Add config for custom terminal.

### DIFF
--- a/lib/connection/terminal.coffee
+++ b/lib/connection/terminal.coffee
@@ -12,16 +12,14 @@ module.exports =
         console.log err
 
   term: (sh) ->
-    if process.platform == "darwin"
-      @exec "osascript -e 'tell application \"Terminal\" to activate'"
-      @exec "osascript -e 'tell application \"Terminal\" to do script \"#{@escape(sh)}\"'"
-    else if process.platform == "windows"
-      @exec "cmd /C start cmd /C #{@escape(sh)}"
-    else if process.platform == "linux"
-      # probably debian-specific
-      @exec "x-terminal-emulator -e \"#{@escape(sh)}\""
-    else
-      console.log 'unsupported platform'
+    switch process.platform
+      when "darwin"
+        @exec "osascript -e 'tell application \"Terminal\" to activate'"
+        @exec "osascript -e 'tell application \"Terminal\" to do script \"#{@escape(sh)}\"'"
+      else
+        @exec "#{@terminal()} \"#{@escape(sh)}\""
+
+  terminal: -> atom.config.get("julia-client.terminal")
 
   jlpath: () -> atom.config.get("julia-client.juliaPath")
   jlargs: () -> atom.config.get("julia-client.juliaArguments")

--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -8,6 +8,15 @@ utils = require './utils'
 completions = require './completions'
 frontend = require './frontend'
 
+defaultTerminal =
+  switch process.platform
+    when 'darwin'
+      'Terminal.app'
+    when 'linux'
+      'x-terminal-emulator -e'
+    else
+      'cmd /C start cmd /C'
+
 module.exports = JuliaClient =
   config:
     juliaPath:
@@ -22,6 +31,10 @@ module.exports = JuliaClient =
       type: 'boolean'
       default: true
       description: 'Enable notifications for evaluation'
+    terminal:
+      type: 'string'
+      default: defaultTerminal
+      description: 'Command used to open a terminal. (Windows/Linux only)'
 
   activate: (state) ->
     @subscriptions = new CompositeDisposable


### PR DESCRIPTION
This is a Linux-only config at the moment (I'd like it to be more general), wasn't sure how to set different defaults for each platform. I've set ``xterm`` as the default since I guessed it's probably installed in more places, happy to change it back to ``x-terminal-emulator`` though if that's the default you want.

Relatedly, have you though of leveraging [term](https://github.com/tjmehta/atom-term) or the [term2](https://github.com/webBoxio/atom-term2) fork instead of opening an external one? They seem to handle the Julia REPL fairly well.