### PR TITLE
Debounce module updates on cursor move

### DIFF
--- a/lib/modules.coffee
+++ b/lib/modules.coffee
@@ -5,17 +5,18 @@ module.exports =
   activate: ->
     @createStatusUI()
 
-    # configure all the events that might require setting or clearing the
-    # cursor move callback
-    atom.workspace.onDidChangeActivePaneItem => @activePaneChanged()
-    client.onConnected => @editorStateChanged()
-    client.onDisconnected => @editorStateChanged()
+    # configure all the events that persist until we're deactivated
+    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem => @activePaneChanged()
+    @connectedSubscription = client.onConnected => @editorStateChanged()
+    @disconnectedSubscription = client.onDisconnected => @editorStateChanged()
     @activePaneChanged()
 
   deactivate: ->
     @tile?.destroy()
     @tile = null
     @activeItemSubscription.dispose()
+    @connectedSubscription.dispose()
+    @disconnectedSubscription.dispose()
 
   activePaneChanged: ->
     @grammarChangeSubscription?.dispose()

--- a/lib/modules.coffee
+++ b/lib/modules.coffee
@@ -27,7 +27,9 @@ module.exports =
   editorStateChanged: ->
     ed = atom.workspace.getActivePaneItem()
     if ed?.getGrammar?().scopeName == 'source.julia' && client.isConnected()
-      @moveSubscription = ed.onDidChangeCursorPosition => @update()
+      @moveSubscription = ed.onDidChangeCursorPosition =>
+        if @pendingUpdate then clearTimeout @pendingUpdate
+        @pendingUpdate = setTimeout (=> @update()), 300
       @update()
     else
       @clear()

--- a/lib/modules.coffee
+++ b/lib/modules.coffee
@@ -1,22 +1,26 @@
 client = require './connection/client'
 selector = require './ui/selector'
+{CompositeDisposable} = require 'atom'
 
 module.exports =
   activate: ->
+    @subscriptions = new CompositeDisposable
     @createStatusUI()
 
     # configure all the events that persist until we're deactivated
-    @activeItemSubscription = atom.workspace.onDidChangeActivePaneItem => @activePaneChanged()
-    @connectedSubscription = client.onConnected => @editorStateChanged()
-    @disconnectedSubscription = client.onDisconnected => @editorStateChanged()
+    @subscriptions.add atom.workspace.onDidChangeActivePaneItem => @activePaneChanged()
+    @subscriptions.add client.onConnected => @editorStateChanged()
+    @subscriptions.add client.onDisconnected => @editorStateChanged()
     @activePaneChanged()
 
   deactivate: ->
     @tile?.destroy()
     @tile = null
-    @activeItemSubscription.dispose()
-    @connectedSubscription.dispose()
-    @disconnectedSubscription.dispose()
+    @subscriptions.dispose()
+    @grammarChangeSubscription?.dispose()
+    @moveSubscription?.dispose()
+    if @pendingUpdate then clearTimeout @pendingUpdate
+
 
   activePaneChanged: ->
     @grammarChangeSubscription?.dispose()

--- a/lib/modules.coffee
+++ b/lib/modules.coffee
@@ -20,7 +20,7 @@ module.exports =
   activePaneChanged: ->
     @grammarChangeSubscription?.dispose()
     ed = atom.workspace.getActivePaneItem()
-    @grammarChangeSubscription = ed?.onDidChangeGrammar => @editorStateChanged()
+    @grammarChangeSubscription = ed?.onDidChangeGrammar? => @editorStateChanged()
     @editorStateChanged()
 
   # sets or clears the callback on cursor change based on the editor state

--- a/lib/modules.coffee
+++ b/lib/modules.coffee
@@ -25,15 +25,17 @@ module.exports =
 
   # sets or clears the callback on cursor change based on the editor state
   editorStateChanged: ->
+    # first clear the display and remove any old subscription
+    @clear()
+    @moveSubscription?.dispose()
+
+    # now see if we need to resubscribe
     ed = atom.workspace.getActivePaneItem()
     if ed?.getGrammar?().scopeName == 'source.julia' && client.isConnected()
       @moveSubscription = ed.onDidChangeCursorPosition =>
         if @pendingUpdate then clearTimeout @pendingUpdate
         @pendingUpdate = setTimeout (=> @update()), 300
       @update()
-    else
-      @clear()
-      @moveSubscription?.dispose()
 
   # Status Bar
 
@@ -93,7 +95,7 @@ module.exports =
     @sub.classList.add 'fade'
 
   # gets the current module from the Julia process and updates the display.
-  # does nothing if we're not connected or not in a julia file
+  # assumes that we're connected and in a julia file
   update: ->
     ed = atom.workspace.getActivePaneItem()
     {row, column} = ed.getCursors()[0].getScreenPosition()


### PR DESCRIPTION
This PR adds debouncing to cursor moves, so we don't try to update
the module we're evaluating into until the user stops moving the
cursor. I was noticing pretty high CPU usage and laggy performance
when typing or moving the cursor with the keyboard.

It also does some refactoring to modules.coffee. The `update` method
was being used to handle a bunch of different callbacks that did
different things depending on the state. This splits out into a
couple different callback handlers. `update` is now only for actually
sending the message to the julia process.