### PR TITLE
fix for `process` being shadowed by imports

### DIFF
--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -1,4 +1,4 @@
-process = require 'child_process'
+child_process = require 'child_process'
 client = require './client'
 net = require 'net'
 
@@ -36,9 +36,9 @@ module.exports =
   spawnJulia: (port) ->
     switch process.platform
       when 'win32'
-        @proc = process.spawn("powershell", ["-ExecutionPolicy", "bypass", "& \"#{__dirname}\\spawnInterruptibleJulia.ps1\" -port #{port} -jlpath \"#{@jlpath()}\" -jloptions \"#{@jlargs().join(' ')}\""])
+        @proc = child_process.spawn("powershell", ["-ExecutionPolicy", "bypass", "& \"#{__dirname}\\spawnInterruptibleJulia.ps1\" -port #{port} -jlpath \"#{@jlpath()}\" -jloptions \"#{@jlargs().join(' ')}\""])
       else
-        @proc = process.spawn(@jlpath(), [@jlargs()..., '-e', "import Atom; @sync Atom.connect(#{port})"])
+        @proc = child_process.spawn(@jlpath(), [@jlargs()..., '-e', "import Atom; @sync Atom.connect(#{port})"])
 
   interruptJulia: ->
     switch process.platform

--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -2,7 +2,7 @@
 http = require 'http'
 terminal = require './connection/terminal'
 client = require './connection/client'
-process = require './connection/process'
+proc = require './connection/process'
 tcp = require './connection/tcp'
 modules = require './modules'
 evaluation = require './eval'
@@ -79,7 +79,7 @@ module.exports = JuliaClient =
           tcp.listen (port) => terminal.client port
       'julia-client:start-julia': =>
         client.disrequire =>
-          tcp.listen (port) => process.start port, cons
+          tcp.listen (port) => proc.start port, cons
       'julia-client:toggle-console': => @withInk => cons.toggle()
       'julia-client:reset-loading-indicator': => client.reset()
 


### PR DESCRIPTION
causing `process.platform` to be undefined.
This leads to e.g. the default platform setting to be wrong on Windows.

ref #35