### PR TITLE
Add NoProfile option to PowerShell call

### DIFF
--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -42,8 +42,8 @@ module.exports =
 
   spawnJulia: (port, cons) ->
     if process.platform == 'win32'
-      if parseInt(child_process.spawnSync("powershell", ["$PSVersionTable.PSVersion.Major"]).output[1].toString()) > 2
-        @proc = child_process.spawn("powershell", ["-ExecutionPolicy", "bypass", "& \"#{__dirname}\\spawnInterruptibleJulia.ps1\" -port #{port} -jlpath \"#{@jlpath()}\" -jloptions \"#{@jlargs().join(' ')}\""], cwd: @workingDir())
+      if parseInt(child_process.spawnSync("powershell", ["-NoProfile", "$PSVersionTable.PSVersion.Major"]).output[1].toString()) > 2
+        @proc = child_process.spawn("powershell", ["-NoProfile", "-ExecutionPolicy", "bypass", "& \"#{__dirname}\\spawnInterruptibleJulia.ps1\" -port #{port} -jlpath \"#{@jlpath()}\" -jloptions \"#{@jlargs().join(' ')}\""], cwd: @workingDir())
         return
       else
         cons.c.out "PowerShell version < 3 encountered. Running without wrapper (interrupts won't work)."


### PR DESCRIPTION
This will prevent any custom PowerShell startup scripts a user might have from running.

In my case I have code in my startup script that doesn't work when called from Atom, just generating errors that are seen in the julia console in Atom. This PR fixes that.