### PR TITLE
Add commands for getting docs/methods

### DIFF
--- a/keymaps/julia-client.cson
+++ b/keymaps/julia-client.cson
@@ -5,6 +5,7 @@
   'cmd-shift-j cmd-shift-m': 'julia-client:reset-working-module'
   'ctrl-`': 'julia-client:toggle-console'
   'ctrl-c': 'julia-client:interrupt-julia'
+  'cmd-j cmd-d': 'julia-client:toggle-documentation'
 
 '.platform-darwin .ink-console':
   'ctrl-c': 'julia-client:interrupt-julia'
@@ -26,6 +27,7 @@
   'ctrl-alt-j ctrl-alt-m': 'julia-client:reset-working-module'
   'ctrl-`': 'julia-client:toggle-console'
   'ctrl-shift-c': 'julia-client:interrupt-julia'
+  'ctrl-j ctrl-d': 'julia-client:toggle-documentation'
 
 '.platform-win32 .ink-console,
  .platform-linux .ink-console':

--- a/lib/eval.coffee
+++ b/lib/eval.coffee
@@ -34,6 +34,31 @@ module.exports =
           @showError r, result.highlights
         notifications.show "Evaluation Finished"
 
+  # get documentation or methods for the current word
+  toggleMeta: (type) ->
+    editor = atom.workspace.getActiveTextEditor()
+    [word, range] = @getWord editor
+    # if we only find numbers or nothing, return prematurely
+    if word.length == 0 || !isNaN(word) then return
+    client.msg type, {code: word}, ({result}) =>
+      view = if result.type then result.view else result
+      view = @ink.tree.fromJson(view)[0]
+      @ink.links.linkify view
+      r = @ink?.results.toggleUnderline editor, range,
+        content: view
+        clas: 'julia'
+
+  # gets the word and its range in the `editor` which the last cursor is on
+  getWord: (editor) ->
+    cursor = editor.getLastCursor()
+    # The following line is kinda iffy: The regex may or may not be well chosen
+    # and it duplicates the efforts from atom-language-julia. It might be
+    # better to select the current word via finding the smallest <span> containing
+    # the cursor which also has `function` or `macro` as its class.
+    range = cursor.getCurrentWordBufferRange({wordRegex: /[\u00A0-\uFFFF\w_!´]*\.?@?[\u00A0-\uFFFF\w_!´]+/})
+    word = editor.getTextInBufferRange range
+    [word, range]
+
   evalAll: ->
     editor = atom.workspace.getActiveTextEditor()
     client.msg 'eval-all', {

--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -71,6 +71,14 @@ module.exports = JuliaClient =
         @withInk =>
           client.start()
           evaluation.evalAll()
+      'julia-client:toggle-documentation': =>
+        @withInk =>
+          client.start()
+          evaluation.toggleMeta 'docs'
+      'julia-client:toggle-methods': =>
+        @withInk =>
+          client.start()
+          evaluation.toggleMeta 'methods'
 
     subs.add atom.commands.add 'atom-workspace',
       'julia-client:open-a-repl': => terminal.repl()


### PR DESCRIPTION
So I basically cleaned up and restructured what code I had for getting methods and documentation on a function or macro.

Atom.jl-side: https://github.com/JunoLab/Atom.jl/pull/17
atom-ink-side: https://github.com/JunoLab/atom-ink/pull/21

This design should be kinda okayish -- let me know what you think ;)

Also: We need default keybindings for those, I think. `Ctrl+D` and `Ctrl+M` are taken, so we could of course do something like `Ctrl+J Ctrl+D/M`. Suggestions?