### PR TITLE
fix escaping bug on windows when opening REPL

### DIFF
--- a/lib/connection/terminal.coffee
+++ b/lib/connection/terminal.coffee
@@ -16,6 +16,8 @@ module.exports =
       when "darwin"
         @exec "osascript -e 'tell application \"Terminal\" to activate'"
         @exec "osascript -e 'tell application \"Terminal\" to do script \"#{@escape(sh)}\"'"
+      when "win32"
+        @exec "#{@terminal()} \"#{sh}\""
       else
         @exec "#{@terminal()} \"#{@escape(sh)}\""
 


### PR DESCRIPTION
`sh` would be escaped so something like `"\"julia\""`, which doesn't work. 

Dunno if this works on linux, someone might wanna check that ;)