### PR TITLE
Rejigger the config

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -27,7 +27,7 @@ if process.platform != 'darwin'
     order: 4
 
 if process.platform == 'win32'
-  config.spawnWrapper =
+  config.enablePowershellWrapper =
     type: 'boolean'
     default: true
     description: 'Use a powershell wrapper to spawn Julia. Necessary to enable interrupts.'

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -1,0 +1,36 @@
+config =
+  juliaPath:
+    type: 'string'
+    default: 'julia'
+    description: 'The location of the Julia binary'
+    order: 1
+  juliaArguments:
+    type: 'string'
+    default: '-q'
+    description: 'Command-line arguments to pass to Julia'
+    order: 2
+  notifications:
+    type: 'boolean'
+    default: true
+    description: 'Enable notifications for evaluation'
+    order: 3
+
+if process.platform != 'darwin'
+  config.terminal =
+    type: 'string'
+    default:
+      if process.platform == 'win32'
+        'cmd /C start cmd /C'
+      else
+        'x-terminal-emulator -e'
+    description: 'Command used to open a terminal.'
+    order: 4
+
+if process.platform == 'win32'
+  config.spawnWrapper =
+    type: 'boolean'
+    default: true
+    description: 'Use a powershell wrapper to spawn Julia. Necessary to enable interrupts.'
+    order: 2.1
+
+module.exports = config

--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -44,7 +44,7 @@ module.exports =
 
   spawnJulia: (port, cons) ->
     if process.platform == 'win32'
-      @useWrapper = atom.config.get("julia-client.spawnWrapper") &&
+      @useWrapper = atom.config.get("julia-client.enablePowershellWrapper") &&
                     parseInt(child_process.spawnSync("powershell", ["-NoProfile", "$PSVersionTable.PSVersion.Major"]).output[1].toString()) > 2
       if @useWrapper
         @proc = child_process.spawn("powershell", ["-NoProfile", "-ExecutionPolicy", "bypass", "& \"#{__dirname}\\spawnInterruptibleJulia.ps1\" -port #{port} -jlpath \"#{@jlpath()}\" -jloptions \"#{@jlargs().join(' ')}\""], cwd: @workingDir())

--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -12,37 +12,8 @@ completions = require './completions'
 frontend = require './frontend'
 cons = require './ui/console'
 
-defaultTerminal =
-  switch process.platform
-    when 'darwin'
-      'Terminal.app'
-    when 'win32'
-      'cmd /C start cmd /C'
-    else
-      'x-terminal-emulator -e'
-
 module.exports = JuliaClient =
-  config:
-    juliaPath:
-      type: 'string'
-      default: 'julia'
-      description: 'The location of the Julia binary'
-    juliaArguments:
-      type: 'string'
-      default: '-q'
-      description: 'Command-line arguments to pass to Julia'
-    notifications:
-      type: 'boolean'
-      default: true
-      description: 'Enable notifications for evaluation'
-    terminal:
-      type: 'string'
-      default: defaultTerminal
-      description: 'Command used to open a terminal. (Windows/Linux only)'
-    spawnWrapper:
-      type: 'boolean'
-      default: true
-      description: 'Use a powershell wrapper to spawn Julia. Necessary to enable interrupts. Windows only, requires powershell version > 2.'
+  config: require './config'
 
   activate: (state) ->
     @subscriptions = new CompositeDisposable


### PR DESCRIPTION
Split into own file for organisational purposes, and adds options depending on the system so that we don't have any "only works on windows" options.