### PR TITLE
Much nicer method view panel

### DIFF
--- a/keymaps/julia-client.cson
+++ b/keymaps/julia-client.cson
@@ -1,11 +1,12 @@
 '.platform-darwin .item-views > atom-text-editor[data-grammar="source julia"]':
   'cmd-enter': 'julia-client:evaluate'
   'cmd-shift-enter': 'julia-client:evaluate-all'
-  'cmd-j cmd-m': 'julia-client:set-working-module'
-  'cmd-shift-j cmd-shift-m': 'julia-client:reset-working-module'
+  'cmd-shift-j cmd-shift-m': 'julia-client:set-working-module'
+  'cmd-alt-j cmd-alt-m': 'julia-client:reset-working-module'
   'ctrl-`': 'julia-client:toggle-console'
   'ctrl-c': 'julia-client:interrupt-julia'
   'cmd-j cmd-d': 'julia-client:toggle-documentation'
+  'cmd-j cmd-m': 'julia-client:toggle-methods'
 
 '.platform-darwin .ink-console':
   'ctrl-c': 'julia-client:interrupt-julia'
@@ -23,11 +24,12 @@
  .platform-linux .item-views > atom-text-editor[data-grammar="source julia"]':
   'ctrl-enter': 'julia-client:evaluate'
   'ctrl-shift-enter': 'julia-client:evaluate-all'
-  'ctrl-j ctrl-m': 'julia-client:set-working-module'
+  'ctrl-shift-j ctrl-shift-m': 'julia-client:set-working-module'
   'ctrl-alt-j ctrl-alt-m': 'julia-client:reset-working-module'
   'ctrl-`': 'julia-client:toggle-console'
   'ctrl-shift-c': 'julia-client:interrupt-julia'
   'ctrl-j ctrl-d': 'julia-client:toggle-documentation'
+  'ctrl-j ctrl-m': 'julia-client:toggle-methods'
 
 '.platform-win32 .ink-console,
  .platform-linux .ink-console':

--- a/lib/eval.coffee
+++ b/lib/eval.coffee
@@ -1,5 +1,8 @@
 client = require './connection/client'
 notifications = require './ui/notifications'
+modules = require './modules'
+methodview = require './ui/method-view'
+
 
 module.exports =
   cursor: ({row, column}) ->
@@ -37,12 +40,14 @@ module.exports =
 
   # get documentation or methods for the current word
   toggleMeta: (type) ->
+    mod = modules.currentModule()
+    mod = if mod then mod else 'Main'
     editor = atom.workspace.getActiveTextEditor()
     [word, range] = @getWord editor
     # if we only find numbers or nothing, return prematurely
     if word.length == 0 || !isNaN(word) then return
-    if type == 'docs'
-      client.msg type, {code: word}, ({result}) =>
+    if type is 'docs'
+      client.msg type, {code: word, module: mod}, ({result}) =>
         view = if result.type then result.view else result
         view = @ink.tree.fromJson(view)[0]
         @ink.links.linkify view
@@ -50,8 +55,10 @@ module.exports =
           content: view
           clas: 'julia'
     else
-      client.msg type, {code: word}, ({result}) =>
-        @ink.methodview.displayMethodView(result)
+      methods = new Promise (resolve) =>
+        client.msg type, {code: word, module: mod}, (result) =>
+          resolve result
+      methodview.displayMethodView(methods)
 
   # gets the word and its range in the `editor` which the last cursor is on
   getWord: (editor) ->

--- a/lib/eval.coffee
+++ b/lib/eval.coffee
@@ -41,13 +41,17 @@ module.exports =
     [word, range] = @getWord editor
     # if we only find numbers or nothing, return prematurely
     if word.length == 0 || !isNaN(word) then return
-    client.msg type, {code: word}, ({result}) =>
-      view = if result.type then result.view else result
-      view = @ink.tree.fromJson(view)[0]
-      @ink.links.linkify view
-      r = @ink?.results.toggleUnderline editor, range,
-        content: view
-        clas: 'julia'
+    if type == 'docs'
+      client.msg type, {code: word}, ({result}) =>
+        view = if result.type then result.view else result
+        view = @ink.tree.fromJson(view)[0]
+        @ink.links.linkify view
+        r = @ink?.results.toggleUnderline editor, range,
+          content: view
+          clas: 'julia'
+    else
+      client.msg type, {code: word}, ({result}) =>
+        @ink.methodview.displayMethodView(result)
 
   # gets the word and its range in the `editor` which the last cursor is on
   getWord: (editor) ->

--- a/lib/ui/method-view.coffee
+++ b/lib/ui/method-view.coffee
@@ -1,0 +1,56 @@
+{$$, SelectListView} = require 'atom-space-pen-views'
+
+module.exports =
+displayMethodView: (promise) ->
+  @view ?= new MethodView()
+  @view.setLoading "Loading..."
+  @view.show()
+  promise.then (items) =>
+    if items.error
+      @view.setError(items.result)
+    else
+      @view.setItems(items.result)
+
+class MethodView extends SelectListView
+  initialize: ->
+    super
+    @panel = atom.workspace.addModalPanel(item: this, visible: false)
+    @addClass('command-palette')
+    @addClass('ink')
+
+  destroy: ->
+    @cancel()
+    @panel.destroy()
+
+  # An item has four fields:
+  #   .signature: Method signature, searchable and displayed.
+  #   .file:      File in which this method is defined, not displayed.
+  #   .dispfile:  Humanized file path, displayed.
+  #   .line:      Line of definition.
+  viewForItem: ({signature, dispfile, line}) ->
+    $$ ->
+      @li class: 'two-lines', =>
+        @div signature, class: 'primary-line'
+        @div dispfile + ":" + line, class: 'secondary-line'
+
+  getFilterKey: -> 'signature'
+
+  populate: (items) ->
+    @setItems(items)
+    @show()
+
+  show: () ->
+    @storeFocusedElement()
+    @panel.show()
+    @focusFilterEditor()
+
+  hide: () ->
+    @panel?.hide()
+
+  confirmed: (item) ->
+    atom.workspace.open item.file,
+      initialLine: item.line
+    @hide()
+
+  cancelled: ->
+    @hide()

--- a/lib/ui/method-view.coffee
+++ b/lib/ui/method-view.coffee
@@ -17,7 +17,6 @@ class MethodView extends SelectListView
     super
     @panel = atom.workspace.addModalPanel(item: this, visible: false)
     @addClass('command-palette')
-    @addClass('ink')
 
   destroy: ->
     @cancel()

--- a/lib/ui/method-view.coffee
+++ b/lib/ui/method-view.coffee
@@ -17,6 +17,7 @@ class MethodView extends SelectListView
     super
     @panel = atom.workspace.addModalPanel(item: this, visible: false)
     @addClass('command-palette')
+    @addClass('method-panel')
 
   destroy: ->
     @cancel()

--- a/lib/ui/method-view.coffee
+++ b/lib/ui/method-view.coffee
@@ -1,4 +1,5 @@
 {$$, SelectListView} = require 'atom-space-pen-views'
+fuzzaldrinPlus = require 'fuzzaldrin-plus'
 
 module.exports =
 displayMethodView: (promise) ->
@@ -28,9 +29,33 @@ class MethodView extends SelectListView
   #   .dispfile:  Humanized file path, displayed.
   #   .line:      Line of definition.
   viewForItem: ({signature, dispfile, line}) ->
+    # the highlighting is taken from https://github.com/atom/command-palette
+    filterQuery = @getFilterQuery()
+    matches = fuzzaldrinPlus.match(signature, filterQuery)
+
     $$ ->
+      highlighter = (command, matches, offsetIndex) =>
+        lastIndex = 0
+        matchedChars = [] # Build up a set of matched chars to be more semantic
+
+        for matchIndex in matches
+          matchIndex -= offsetIndex
+          continue if matchIndex < 0 # If marking up the basename, omit command matches
+          unmatched = command.substring(lastIndex, matchIndex)
+          if unmatched
+            @span matchedChars.join(''), class: 'character-match' if matchedChars.length
+            matchedChars = []
+            @text unmatched
+          matchedChars.push(command[matchIndex])
+          lastIndex = matchIndex + 1
+
+        @span matchedChars.join(''), class: 'character-match' if matchedChars.length
+
+        # Remaining characters are plain text
+        @text command.substring(lastIndex)
+
       @li class: 'two-lines', =>
-        @div signature, class: 'primary-line'
+        @div class: 'primary-line', -> highlighter(signature, matches, 0)
         @div dispfile + ":" + line, class: 'secondary-line'
 
   getFilterKey: -> 'signature'

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "atom": ">=1.0.0 <2.0.0"
   },
   "dependencies": {
-    "atom-space-pen-views": "^2.0.0"
+    "atom-space-pen-views": "^2.0.0",
+    "fuzzaldrin-plus": "^0.1.0"
   },
   "consumedServices": {
     "status-bar": {

--- a/styles/julia-client.less
+++ b/styles/julia-client.less
@@ -35,3 +35,18 @@ atom-text-editor::shadow {
     z-index: 1;
   }
 }
+
+.method-panel {
+  .two-lines {
+    padding: 0.2em 0.75em 0.2em 1em !important;
+    .primary-line, .secondary-line {
+      line-height: 1.8em;
+    }
+  }
+  .error-message {
+    color: @text-color-error;
+  }
+  .character-match {
+    font-weight: bold;
+  }
+}


### PR DESCRIPTION
This implements a nicer and searchable frontend for the `toggle methods` command, as mentioned in #76.

![methodview](https://cloud.githubusercontent.com/assets/6735977/12217361/0eb19856-b6fe-11e5-909b-acc97d578245.png)

[Julia side](https://github.com/JunoLab/Atom.jl/pull/20).
~~[Ink side](https://github.com/JunoLab/atom-ink/pull/25).~~

ToDo:
- [x] Default shortcut!
- [ ] style improvements, maybe? I'm open to suggestions. cc @spencerlyon2, @mfcd
- [x]  highlighting of matched keywords. That is actually not all that hard, see [here](https://github.com/atom/command-palette/blob/86741d106dbdc4860922e1b8bfded97dd699c274/lib/command-palette-view.coffee#L74-L92), but I didn't feel like copying their method just like that...
- [x]  Just thought of it -- this should probably be implemented with a `promise`, right?
- [x]  Errors should be handled gracefully instead of not at all. 