### PR TITLE
Modified ps script for working interrupts on Windows

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -26,7 +26,7 @@ if process.platform != 'darwin'
 if process.platform == 'win32'
   config.enablePowershellWrapper =
     type: 'boolean'
-    default: false
+    default: true
     description: 'Use a powershell wrapper to spawn Julia. Necessary to enable interrupts.'
     order: 2.5
 

--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -107,9 +107,6 @@ module.exports =
       @proc.kill('SIGINT')
 
   killJulia: ->
-    if process.platform == 'win32' && @useWrapper
-      @sendSignalToWrapper('KILL')
-    else
       @proc.kill()
 
   sendSignalToWrapper: (signal) ->

--- a/lib/connection/spawnInterruptibleJulia.ps1
+++ b/lib/connection/spawnInterruptibleJulia.ps1
@@ -63,4 +63,8 @@ while ($true){
 			echo "julia-client: Internal Error: Interrupting Julia failed."
 		}
 	}
+	if ($msg -match "KILL"){
+		$proc.Kill()
+		Exit
+	}
 }

--- a/lib/connection/spawnInterruptibleJulia.ps1
+++ b/lib/connection/spawnInterruptibleJulia.ps1
@@ -1,8 +1,12 @@
 param(
 	[Int32] $port,
 	[string] $jlpath,
-	[string] $boot
+	[string] $boot,
+	[string] $cwd
 )
+
+# change to working dir:
+cd $cwd
 
 # start Julia
 $proc = Start-Process $jlpath @($boot, $port) -NoNewWindow -PassThru
@@ -11,9 +15,14 @@ $proc = Start-Process $jlpath @($boot, $port) -NoNewWindow -PassThru
 $MethodDefinition = @'
 [DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
 public static extern bool GenerateConsoleCtrlEvent(uint dwCtrlEvent, uint dwProcessGroupId);
+[DllImport("Kernel32.dll", CharSet = CharSet.Unicode)]
+public static extern bool SetConsoleCtrlHandler(EventHandler handler, bool add);
 '@
 
 $Kernel32 = Add-Type -MemberDefinition $MethodDefinition -Name 'Kernel32' -Namespace 'Win32' -PassThru
+
+# keep us alive!
+$status = $Kernel32::SetConsoleCtrlHandler($null, $true)
 
 function Receive-TCPMessage {
     param ( [ValidateNotNullOrEmpty()]

--- a/lib/connection/spawnInterruptibleJulia.ps1
+++ b/lib/connection/spawnInterruptibleJulia.ps1
@@ -63,8 +63,4 @@ while ($true){
 			echo "julia-client: Internal Error: Interrupting Julia failed."
 		}
 	}
-	if ($msg -match "KILL"){
-		$proc.Kill()
-		Exit
-	}
 }


### PR DESCRIPTION
and a couple of windows fixes in process.coffee.

@one-more-minute: The additional `cwd: @workingDir()` you added to the `powershell` invocation errors for me -- powershell cannot be spawned with it there.

I also added the early return in `checkExe` you suggested.