### PR TITLE
maintain spacing in status bar module indicator

### DIFF
--- a/lib/runtime/modules.coffee
+++ b/lib/runtime/modules.coffee
@@ -47,7 +47,7 @@ module.exports =
 
   createStatusUI: ->
     @dom = document.createElement 'span'
-    @dom.classList.add 'julia-client'
+    @dom.classList.add 'julia-client', 'inline-block'
     @main = document.createElement 'a'
     @sub = document.createElement 'span'
     @divider = document.createElement 'span'


### PR DESCRIPTION
Before this change:

<img width="399" alt="screen shot 2016-01-21 at 3 09 10 pm" src="https://cloud.githubusercontent.com/assets/1001948/12493045/4d33d25e-c051-11e5-8644-be351276d742.png">


After the change:

<img width="400" alt="screen shot 2016-01-21 at 3 08 23 pm" src="https://cloud.githubusercontent.com/assets/1001948/12493048/511aa0f0-c051-11e5-9acf-703e650eaae8.png">
