### PR TITLE
make checking the julia executable more robust

### DIFF
--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -60,6 +60,7 @@ module.exports = jlprocess =
       # check whether path exists
       fs.stat p, (err, stats) =>
         if not err
+          # and is a file
           if stats.isFile() then resolve(); return
           # if it isn't, look for a file called `julia(.exe)`
           fs.readdir p, (err, files) =>

--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -59,26 +59,18 @@ module.exports = jlprocess =
     new Promise (resolve, reject) =>
       # check whether path exists
       fs.stat p, (err, stats) =>
-        console.log err
         if not err
-          if stats.isFile()
-            resolve()
-          else
-            # if it isn't, look for a file called `julia(.exe)`
-            fs.readdir p, (err, files) =>
-              if err then reject()
-              if files.indexOf(@executable()) > 0
-                newpath = path.join p, @executable()
-                # check whether that file is no directory
-                fs.stat newpath, (err, stats) =>
-                  if stats.isFile()
-                    # change the `Julia Path` setting to that new path and carry on
-                    atom.config.set 'julia-client.juliaPath', newpath
-                    resolve()
-                  else
-                    reject()
-              else
-                reject()
+          if stats.isFile() then resolve(); return
+          # if it isn't, look for a file called `julia(.exe)`
+          fs.readdir p, (err, files) =>
+            if err or files.indexOf(@executable()) < 0 then reject(); return
+            newpath = path.join p, @executable()
+            # check whether that file is no directory
+            fs.stat newpath, (err, fstats) =>
+              # change the `Julia Path` setting to that new path and carry on
+              if not fstats.isFile() then reject(); return
+              atom.config.set 'julia-client.juliaPath', newpath
+              resolve()
         # fallback to calling `which` or `where` on the path
         else
           which = if process.platform is 'win32' then 'where' else 'which'

--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -58,27 +58,27 @@ module.exports = jlprocess =
   checkPath: (p) ->
     new Promise (resolve, reject) =>
       # check whether path exists
-      fs.exists p, (exists) =>
-        if exists
-          # check whether the path actually is a file
-          fs.stat p, (err, stats) =>
-            if stats.isFile()
-              resolve()
-            else
-              # if it isn't, look for a file called `julia(.exe)`
-              fs.readdir p, (err, files) =>
-                if files.indexOf(@executable()) > 0
-                  newpath = path.join p, @executable()
-                  # check whether that file is no directory
-                  fs.stat newpath, (err, stats) =>
-                    if stats.isFile()
-                      # change the `Julia Path` setting to that new path and carry on
-                      atom.config.set 'julia-client.juliaPath', newpath
-                      resolve()
-                    else
-                      reject()
-                else
-                  reject()
+      fs.stat p, (err, stats) =>
+        console.log err
+        if not err
+          if stats.isFile()
+            resolve()
+          else
+            # if it isn't, look for a file called `julia(.exe)`
+            fs.readdir p, (err, files) =>
+              if err then reject()
+              if files.indexOf(@executable()) > 0
+                newpath = path.join p, @executable()
+                # check whether that file is no directory
+                fs.stat newpath, (err, stats) =>
+                  if stats.isFile()
+                    # change the `Julia Path` setting to that new path and carry on
+                    atom.config.set 'julia-client.juliaPath', newpath
+                    resolve()
+                  else
+                    reject()
+              else
+                reject()
         # fallback to calling `which` or `where` on the path
         else
           which = if process.platform is 'win32' then 'where' else 'which'

--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -38,13 +38,17 @@ module.exports = jlprocess =
 
   script: (s...) -> @packageDir 'script', s...
 
-  # spawn Julia in the first open project folder (or its parent folder for files)
   workingDir: ->
     paths = atom.workspace.project.getDirectories()
-    if fs.statSync(paths[0].path).isFile()
-      path.dirname paths[0].path
+    if paths.length > 0
+      # spawn Julia in the first open project folder (or its parent folder for files)
+      if fs.statSync(paths[0].path).isFile()
+        path.dirname paths[0].path
+      else
+        paths[0].path
     else
-      paths[0].path
+      # or in HOME if there are no open project folders
+      process.env.HOME || process.env.USERPROFILE
 
   jlpath: ->
     p = atom.config.get("julia-client.juliaPath")

--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -101,24 +101,24 @@ module.exports = jlprocess =
     client.booting()
 
     @checkPath(@jlpath())
-    .then =>
-      @spawnJulia port, =>
-        @proc.on 'exit', (code, signal) =>
-          @emitter.emit 'stderr', "Julia has stopped"
-          if not @useWrapper then @emitter.emit 'stderr', ": #{code}, #{signal}"
-          @proc = null
-          client.cancelBoot()
-        @proc.stdout.on 'data', (data) =>
-          text = data.toString()
-          if text then @emitter.emit 'stdout', text
-          if text and @pipeConsole then console.log text
-        @proc.stderr.on 'data', (data) =>
-          text = data.toString()
-          if text then @emitter.emit 'stderr', text
-          if text and @pipeConsole then console.info text
-    .catch =>
-      @jlNotFound @jlpath()
-      client.cancelBoot()
+      .then =>
+        @spawnJulia port, =>
+          @proc.on 'exit', (code, signal) =>
+            @emitter.emit 'stderr', "Julia has stopped"
+            if not @useWrapper then @emitter.emit 'stderr', ": #{code}, #{signal}"
+            @proc = null
+            client.cancelBoot()
+          @proc.stdout.on 'data', (data) =>
+            text = data.toString()
+            if text then @emitter.emit 'stdout', text
+            if text and @pipeConsole then console.log text
+          @proc.stderr.on 'data', (data) =>
+            text = data.toString()
+            if text then @emitter.emit 'stderr', text
+            if text and @pipeConsole then console.info text
+      .catch =>
+        @jlNotFound @jlpath()
+        client.cancelBoot()
 
   spawnJulia: (port, fn) ->
     if process.platform is 'win32' and atom.config.get("julia-client.enablePowershellWrapper")


### PR DESCRIPTION
and spawn julia in the first open project folder (or its parent if that is a file), as per [here](https://github.com/JunoLab/atom-julia-client/issues/124#issuecomment-193303789).