### PR TITLE
WIP: option to bypass atom's notification UI for errors

### DIFF
--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -9,11 +9,12 @@ module.exports =
     @client.boot = => @boot()
     @process.activate()
 
-    @client.handle 'error', (options) =>
-      if atom.config.get("julia-client.errorsToConsole")
-        @process.emitter.emit 'stderr', options.msg + '\n' + options.detail
-      else
-        atom.notifications.addError options.msg, options
+    atom.config.observe 'julia-client.errorsToConsole', (val) =>
+      @client.handle 'error', (options) =>
+        if val
+          @process.emitter.emit 'stderr', options.msg + '\n' + options.detail
+        else
+          atom.notifications.addError options.msg, options
 
     if atom.config.get("julia-client.launchOnStartup")
       atom.commands.dispatch atom.views.getView(atom.workspace),

--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -11,7 +11,7 @@ module.exports =
 
     @client.handle 'error', (options) =>
       if atom.config.get("julia-client.errorsToConsole")
-        process.emitter.emit 'stderr', options.msg
+        @process.emitter.emit 'stderr', options.msg + '\n' + options.detail
       else
         atom.notifications.addError options.msg, options
 

--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -11,7 +11,7 @@ module.exports =
 
     @client.handle 'error', (options) =>
       if atom.config.get("julia-client.errorsToConsole")
-        console.log('TODO: send this error to the console!!')
+        process.emitter.emit 'stderr', options.msg
       else
         atom.notifications.addError options.msg, options
 

--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -10,7 +10,10 @@ module.exports =
     @process.activate()
 
     @client.handle 'error', (options) =>
-      atom.notifications.addError options.msg, options
+      if atom.config.get("julia-client.errorsToConsole")
+        console.log('TODO: send this error to the console!!')
+      else
+        atom.notifications.addError options.msg, options
 
     if atom.config.get("julia-client.launchOnStartup")
       atom.commands.dispatch atom.views.getView(atom.workspace),

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -16,23 +16,28 @@ config =
     default: true
     description: 'Enable notifications for evaluation.'
     order: 3
+  errorsToConsole:
+    type: 'boolean'
+    default: false
+    description: 'Show errors in console. If false use atom\'s nofitication UI'
+    order: 4
   enableMenu:
     type: 'boolean'
     default: proc.isBundled()
     description: 'Show a Julia menu in the menu bar (requires restart).'
-    order: 4
+    order: 5
   enableToolBar:
     type: 'boolean'
     default: proc.isBundled()
     description: 'Show Julia icons in the tool bar.'
-    order: 5
+    order: 6
 
 if process.platform != 'darwin'
   config.terminal =
     type: 'string'
     default: terminal.defaultTerminal()
     description: 'Command used to open a terminal.'
-    order: 6
+    order: 7
 
 if process.platform == 'win32'
   config.enablePowershellWrapper =


### PR DESCRIPTION
This adds an option to have Julia runtime errors show up in the console rather than using Atom's notification UI when evaluating from the source file. 

It isn't finished as I didn't have a chance to hook up the part where we send the error to the console. I don't have time to dig into it myself right now, so if either @MikeInnes @pfitzseb  could fill in the `TODO` I logged to the console that would be great.

Thanks!

cc @simonbyrne