### PR TITLE
Julia As A Service

### DIFF
--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -23,7 +23,6 @@ module.exports =
         'julia-client:start-julia'
 
   deactivate: ->
-    @process.deactivate()
 
   consumeInk: (ink) ->
     @client.loading = new ink.Loading

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -118,6 +118,16 @@ module.exports =
 
   # Management & UI
 
+  clientCall: (name, f, args...) ->
+    if not @conn[f]?
+      atom.notifications.addError "This client doesn't support #{name}."
+    else
+      @conn[f].call @conn, args...
+
+  stdin: (data) -> @clientCall 'STDIN', 'stdin', data
+  interrupt: -> @clientCall 'interrupts', 'interrupt'
+  kill: -> @clientCall 'kill', 'kill'
+
   connectedError: ->
     if @isActive()
       atom.notifications.addError "Can't start a Julia process.",
@@ -127,7 +137,7 @@ module.exports =
       false
 
   notConnectedError: ->
-    if not @isActive()
+    if not @isConnected()
       atom.notifications.addError "Can't do that without a Julia client.",
         detail: "Try connecting a client by evaluating something."
       true

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -130,8 +130,16 @@ module.exports =
       @conn[f].call @conn, args...
 
   stdin: (data) -> @clientCall 'STDIN', 'stdin', data
-  interrupt: -> @clientCall 'interrupts', 'interrupt'
-  kill: -> @clientCall 'kill', 'kill'
+
+  interrupt: ->
+    if @isConnected() and @isWorking()
+      @clientCall 'interrupts', 'interrupt'
+
+  kill: ->
+    if @isConnected() and not @isWorking()
+      @rpc('exit').catch ->
+    else
+      @clientCall 'kill', 'kill'
 
   connectedError: (action = 'do that') ->
     if @isConnected()

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -152,7 +152,9 @@ module.exports =
       false
 
   notConnectedError: (action = 'do that') ->
-    if not @isConnected()
+    if @isBooting()
+      atom.notifications.addError "Can't #{action} until Julia finishes booting."
+    else if not @isConnected()
       atom.notifications.addError "Can't #{action} without a Julia client.",
         detail: "Start Julia using Packages → Julia → Start Julia."
       true

--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -144,6 +144,7 @@ module.exports = jlprocess =
       client.stderr text
     conn.interrupt = => @interrupt conn.proc
     conn.kill = => @kill conn.proc
+    conn.stdin = (data) -> conn.proc.stdin.write data
     client.connected conn
 
   start: (port) ->

--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -6,8 +6,6 @@ fs =            require 'fs'
 client = require './client'
 tcp = require './tcp'
 
-{exit} = client.import 'exit'
-
 module.exports =
 
   activate: ->
@@ -193,20 +191,16 @@ module.exports =
       fn()
 
   interrupt: (proc) ->
-    if client.isConnected() and client.isWorking()
-      if @useWrapper
-        @sendSignalToWrapper('SIGINT')
-      else
-        proc.kill('SIGINT')
+    if @useWrapper
+      @sendSignalToWrapper('SIGINT')
+    else
+      proc.kill('SIGINT')
 
   kill: (proc) ->
-    if client.isConnected() and not client.isWorking()
-      exit()
+    if @useWrapper
+      @sendSignalToWrapper('KILL')
     else
-      if @useWrapper
-        @sendSignalToWrapper('KILL')
-      else
-        proc.kill()
+      proc.kill()
 
   sendSignalToWrapper: (signal) ->
     wrapper = net.connect(port: @wrapPort)

--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -8,9 +8,12 @@ tcp = require './tcp'
 
 {exit} = client.import 'exit'
 
-module.exports = jlprocess =
+module.exports =
 
   activate: ->
+    client.onDisconnected ->
+      if @useWrapper and @proc
+        @proc.kill()
 
     client.handle 'welcome', ->
       atom.notifications.addSuccess "Welcome to Juno!",
@@ -210,7 +213,3 @@ module.exports = jlprocess =
     wrapper.setNoDelay()
     wrapper.write(signal)
     wrapper.end()
-
-client.onDisconnected ->
-  if jlprocess.useWrapper and jlprocess.proc
-    jlprocess.proc.kill()

--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -29,5 +29,7 @@ module.exports = JuliaClient =
 
   consumeToolBar: (bar) -> toolbar.consumeToolBar bar
 
+  provideClient: -> @connection.client
+
   config: require './package/config'
   completions: -> require './runtime/completions'

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -3,8 +3,8 @@ shell =                 require 'shell'
 
 module.exports =
   activate: (juno) ->
-    requireClient    = (f) -> juno.connection.client.require f
-    disrequireClient = (f) -> juno.connection.client.disrequire f
+    requireClient    = (a, f) -> juno.connection.client.require a, f
+    disrequireClient = (a, f) -> juno.connection.client.disrequire a, f
     boot = -> juno.connection.boot()
 
     cancelComplete = (e) ->
@@ -36,7 +36,7 @@ module.exports =
           boot()
           juno.runtime.evaluation.toggleMeta 'methods'
       'julia-client:reset-workspace': =>
-        requireClient ->
+        requireClient 'reset the workspace', ->
           editor = atom.workspace.getActiveTextEditor()
           atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
           juno.connection.client.rpc('clear-workspace')
@@ -49,9 +49,9 @@ module.exports =
 
     @subs.add atom.commands.add 'atom-workspace',
       'julia-client:open-a-repl': -> juno.connection.terminal.repl()
-      'julia-client:start-julia': -> disrequireClient -> boot()
-      'julia-client:kill-julia': => requireClient -> juno.connection.client.kill()
-      'julia-client:interrupt-julia': => requireClient -> juno.connection.client.interrupt()
+      'julia-client:start-julia': -> disrequireClient 'boot Julia', -> boot()
+      'julia-client:kill-julia': => requireClient 'kill Julia', -> juno.connection.client.kill()
+      'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
       'julia-client:open-console': => @withInk -> juno.runtime.console.open()
       "julia-client:clear-console": => juno.runtime.console.reset()
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()
@@ -65,13 +65,17 @@ module.exports =
       'julia:open-package-in-new-window': -> juno.misc.paths.openPackage()
 
       'julia-client:work-in-file-folder': ->
-        requireClient -> juno.runtime.evaluation.cdHere()
+        requireClient 'change working folder', ->
+          juno.runtime.evaluation.cdHere()
       'julia-client:work-in-project-folder': ->
-        requireClient -> juno.runtime.evaluation.cdProject()
+        requireClient 'change working folder', ->
+          juno.runtime.evaluation.cdProject()
       'julia-client:work-in-home-folder': ->
-        requireClient -> juno.runtime.evaluation.cdHome()
+        requireClient 'change working folder', ->
+          juno.runtime.evaluation.cdHome()
       'julia-client:select-working-folder': ->
-        requireClient -> juno.runtime.evaluation.cdSelect()
+        requireClient 'change working folder', ->
+          juno.runtime.evaluation.cdSelect()
 
   deactivate: ->
     @subs.dispose()

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -42,6 +42,16 @@ module.exports =
           juno.connection.client.rpc('clear-workspace')
       'julia:select-block': =>
         juno.misc.blocks.select()
+      'julia-client:send-to-stdin': (e) =>
+        requireClient ->
+          ed = e.currentTarget.getModel()
+          done = false
+          for s in ed.getSelections()
+            continue unless s.getText()
+            done = true
+            juno.connection.client.stdin s.getText()
+          juno.connection.client.stdin ed.getText() unless done
+
 
     @subs.add atom.commands.add '.item-views > atom-text-editor[data-grammar="source julia"],
                                  ink-console.julia',

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -50,6 +50,8 @@ module.exports =
     @subs.add atom.commands.add 'atom-workspace',
       'julia-client:open-a-repl': -> juno.connection.terminal.repl()
       'julia-client:start-julia': -> disrequireClient -> boot()
+      'julia-client:kill-julia': => requireClient -> juno.connection.client.kill()
+      'julia-client:interrupt-julia': => requireClient -> juno.connection.client.interrupt()
       'julia-client:open-console': => @withInk -> juno.runtime.console.open()
       "julia-client:clear-console": => juno.runtime.console.reset()
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()

--- a/lib/runtime/console.coffee
+++ b/lib/runtime/console.coffee
@@ -31,8 +31,8 @@ module.exports =
 
     client.handle 'input', => @input()
 
-    client.onStdout (s) => @c.stdout s
-    client.onStderr (s) => @c.stderr s
+    client.onStdout (s) => @stdout s
+    client.onStderr (s) => @stderr s
 
   deactivate: ->
     @subs.dispose()
@@ -49,6 +49,17 @@ module.exports =
     atom.views.getView(@c).classList.add 'julia'
     history.read().then (entries) =>
       @c.history.set entries
+
+  ignored: ['WARNING: Method definition require(Symbol)']
+  ignore: (s) ->
+    for i in @ignored
+      return true if s.startsWith(i)
+
+  stdout: (data) -> @c.stdout data
+
+  stderr: (data) ->
+    data = data.split('\n').filter((x)=>!@ignore x).join("\n")
+    if data then @c.stderr data
 
   open: ->
     # Seems like atom should be doing this check for us,

--- a/lib/runtime/console.coffee
+++ b/lib/runtime/console.coffee
@@ -2,7 +2,7 @@
 
 {history} = require '../misc'
 {notifications, views} = require '../ui'
-{client, process} = require '../connection'
+{client} = require '../connection'
 
 modules = require './modules'
 
@@ -31,8 +31,8 @@ module.exports =
 
     client.handle 'input', => @input()
 
-    process.onStdout (s) => @c.stdout s
-    process.onStderr (s) => @c.stderr s
+    client.onStdout (s) => @c.stdout s
+    client.onStderr (s) => @c.stderr s
 
   deactivate: ->
     @subs.dispose()

--- a/lib/runtime/modules.coffee
+++ b/lib/runtime/modules.coffee
@@ -55,7 +55,7 @@ module.exports =
     item = atom.workspace.getActivePaneItem()
     ised = atom.workspace.isTextEditor item
     return unless @isValidItem item
-    client.require =>
+    client.require 'change modules', =>
       if (item = atom.workspace.getActivePaneItem())
         active = item.juliaModule or (if ised then @autodetect else 'Main')
         modules = allmodules().then (modules) =>

--- a/package.json
+++ b/package.json
@@ -35,6 +35,12 @@
       "versions": {
         "2.0.0": "completions"
       }
+    },
+    "julia-client": {
+      "description": "Run a Julia process",
+      "versions": {
+        "0.1.0": "provideClient"
+      }
     }
   }
 }


### PR DESCRIPTION
Cleans up the connection architecture and exposes the `client` object as a service.

What this means is that if packages want to extend what Juno can do – including by adding new ways of connecting to a client, e.g. over SSH – they can just grab the `client` object and get on with it. Equally, it might be possible to e.g. implement a profiler as an Atom plugin + Julia package on top of Atom.jl and julia-client.

Couple extras: better error messages, and a command which sends text to Julia's STDIN.