### PR TITLE
internal errors always rendered in console, notification is opt-out

### DIFF
--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -50,12 +50,12 @@ module.exports =
       @callbacks[id].reject "cancelled by julia"
       @loading.done()
 
-    atom.config.observe 'julia-client.errorsToConsole', (toConsole) =>
-      @handle 'error', (options) =>
-        if toConsole
-          @stderr options.msg + '\n' + options.detail
-        else
+    atom.config.observe 'julia-client.errorNotifications', (notif) =>
+      if notif
+        @handle 'error', (options) =>
           atom.notifications.addError options.msg, options
+      else
+        @handle 'error', (options) => # let's throw this away
 
   msg: (type, args...) ->
     if @isConnected()

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -51,11 +51,9 @@ module.exports =
       @loading.done()
 
     atom.config.observe 'julia-client.errorNotifications', (notif) =>
-      if notif
-        @handle 'error', (options) =>
-          atom.notifications.addError options.msg, options
-      else
-        @handle 'error', (options) => # let's throw this away
+      @handle 'error', (options) =>
+        if notif
+            atom.notifications.addError options.msg, options
 
   msg: (type, args...) ->
     if @isConnected()

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -31,11 +31,11 @@ config =
     default: true
     description: 'Enable notifications for evaluation.'
     order: 4
-  errorsToConsole:
+  errorNotifications:
     type: 'boolean'
-    default: false
-    description: 'When evaluating a script, show errors in the console instead
-                  of using a notification.'
+    default: true
+    description: 'When evaluating a script, show errors in a notification as
+                  well as in the console.'
     order: 5
   enableMenu:
     type: 'boolean'


### PR DESCRIPTION
motivated by #151.

Also change the recently introduced `Errors To Console` option to an opt-out setting for notifications for those kinds of errors.

julia side: https://github.com/JunoLab/Atom.jl/pull/34

cc: @dlfivefifty