### PR TITLE
get the correct versions packages

### DIFF
--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -196,6 +196,25 @@ module.exports =
         cwd: workingdir
       fn proc
 
+  getVersion: (fn) ->
+    p = new Promise (resolve, reject) =>
+      # not sure if the return here is necessary, but I think the rest of the
+      # code will be unnecessarily executed otherwise
+      if @version? then resolve(@version); return
+      @checkPath(@jlpath())
+        .then =>
+          proc = child_process.spawn @jlpath(), ["--version"]
+          proc.on 'exit', () =>
+            str = proc.stdout.read().toString()
+            res = str.match /(\d+)\.(\d+)\.(\d+)/
+            if res?
+              [_, major, minor, patch] = res
+              @version = {major, minor, patch}
+              resolve @version
+            else
+              reject()
+        .catch => reject()
+
   getFreePort: (fn) ->
     server = net.createServer()
     server.listen 0, '127.0.0.1', =>

--- a/lib/connection/process.coffee
+++ b/lib/connection/process.coffee
@@ -196,25 +196,6 @@ module.exports =
         cwd: workingdir
       fn proc
 
-  getVersion: (fn) ->
-    p = new Promise (resolve, reject) =>
-      # not sure if the return here is necessary, but I think the rest of the
-      # code will be unnecessarily executed otherwise
-      if @version? then resolve(@version); return
-      @checkPath(@jlpath())
-        .then =>
-          proc = child_process.spawn @jlpath(), ["--version"]
-          proc.on 'exit', () =>
-            str = proc.stdout.read().toString()
-            res = str.match /(\d+)\.(\d+)\.(\d+)/
-            if res?
-              [_, major, minor, patch] = res
-              @version = {major, minor, patch}
-              resolve @version
-            else
-              reject()
-        .catch => reject()
-
   getFreePort: (fn) ->
     server = net.createServer()
     server.listen 0, '127.0.0.1', =>

--- a/lib/misc/paths.coffee
+++ b/lib/misc/paths.coffee
@@ -2,6 +2,7 @@
 
 path =  require 'path'
 fs =    require 'fs'
+proc = require '../connection/process'
 
 module.exports =
 
@@ -16,8 +17,12 @@ module.exports =
     new Promise (resolve, reject) =>
       fs.readdir @juliaHome(), (err, data) =>
         if err? then return reject err
-        dir = data?.filter((path)=>path.startsWith('v')).sort().pop()
-        if dir? then resolve @juliaHome dir else reject()
+        proc.getVersion()
+          .then (ver) =>
+            r = new RegExp("v#{ver.major}\\.#{ver.minor}")
+            dir = data?.filter((path) => path.search(r) > -1)[0]
+            if dir? then resolve @juliaHome dir else reject()
+          .catch => reject()
 
   packages: ->
     @pkgDir().then (dir) =>


### PR DESCRIPTION
This fixes #159. 
Only works with a functioning and correctly set julia executable, but I think that's a tradeoff everyone should be okay with. 

The regexp for getting the current version may or may not be a good idea -- no clue if Julias versioning scheme will change anytime soon. Maybe I should add a generic fallback similar to what we had before, but not sure. Opinions?