### PR TITLE
limit the console history's size

### DIFF
--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -47,13 +47,18 @@ config =
     default: proc.isBundled()
     description: 'Show Julia icons in the tool bar (requires restart).'
     order: 7
+  maximumConsoleSize:
+    type: 'integer'
+    description: "Limits the Console history's size."
+    default: 10000
+    order: 8
 
 if process.platform != 'darwin'
   config.terminal =
     type: 'string'
     default: terminal.defaultTerminal()
     description: 'Command used to open a terminal.'
-    order: 8
+    order: 9
 
 if process.platform == 'win32'
   config.enablePowershellWrapper =

--- a/lib/runtime/console.coffee
+++ b/lib/runtime/console.coffee
@@ -12,6 +12,9 @@ module.exports =
   activate: ->
     @create()
 
+    atom.config.observe 'julia-client.maximumConsoleSize', (size) =>
+      @c.maxSize = size
+
     @subs = new CompositeDisposable
 
     @subs.add atom.workspace.addOpener (uri) =>


### PR DESCRIPTION
Fixes #166, requires https://github.com/JunoLab/atom-ink/pull/51.

Not sure how sensible that default is though...