### PR TITLE
install Ink via atom-package-deps

### DIFF
--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -9,9 +9,21 @@ module.exports = JuliaClient =
   runtime:    require './runtime'
 
   activate: (state) ->
-    commands.activate @
-    x.activate() for x in [menu, @connection, @runtime]
-    @ui.activate @connection.client
+  	@requireInk =>
+      commands.activate @
+      x.activate() for x in [menu, @connection, @runtime]
+      @ui.activate @connection.client
+
+  requireInk: (fn) ->
+    if atom.packages.isPackageLoaded "ink" then fn()
+    else
+      require('atom-package-deps').install('julia-client')
+        .then  -> fn()
+        .catch -> 
+          atom.notifications.addError 'Installing the Ink package failed.',
+            detail: 'Julia Client requires the Ink package to run.
+                     Please install it manually from the settings view.'
+            dismissable: true
 
   deactivate: ->
     x.deactivate() for x in [commands, menu, toolbar, @connection, @runtime, @ui]

--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -9,7 +9,7 @@ module.exports = JuliaClient =
   runtime:    require './runtime'
 
   activate: (state) ->
-  	@requireInk =>
+    @requireInk =>
       commands.activate @
       x.activate() for x in [menu, @connection, @runtime]
       @ui.activate @connection.client
@@ -19,7 +19,7 @@ module.exports = JuliaClient =
     else
       require('atom-package-deps').install('julia-client')
         .then  -> fn()
-        .catch -> 
+        .catch ->
           atom.notifications.addError 'Installing the Ink package failed.',
             detail: 'Julia Client requires the Ink package to run.
                      Please install it manually from the settings view.'

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
     "underscore-plus": "*",
+    "atom-package-deps": "*",
     "highlights": "*"
   },
   "consumedServices": {
@@ -43,5 +44,6 @@
         "0.1.0": "provideClient"
       }
     }
-  }
+  },
+  "package-deps": ["ink"]
 }


### PR DESCRIPTION
We could probably get rid of all those `withInk`s, but then again ink might be activated while Juno runs...