### PR TITLE
Highlighting in results without external dependency

### DIFF
--- a/lib/ui/highlighter.coffee
+++ b/lib/ui/highlighter.coffee
@@ -1,0 +1,64 @@
+
+# stolen from https://github.com/atom/highlights/blob/master/src/highlights.coffee
+# uses Atoms grammars
+module.exports =
+  highlight: (line, @grammar) ->
+    _highlightCommon line
+
+  _highlightCommon: (text) ->
+    lineTokens = @grammar.tokenizeLines(text)
+
+    # Remove trailing newline
+    if lineTokens.length > 0
+      lastLineTokens = lineTokens[lineTokens.length - 1]
+
+      if lastLineTokens.length is 1 and lastLineTokens[0].value is ''
+        lineTokens.pop()
+
+    html = '<pre class="editor editor-colors">'
+    for tokens in lineTokens
+      scopeStack = []
+      html += '<div class="line">'
+      for {value, scopes} in tokens
+        value = ' ' unless value
+        html = @updateScopeStack(scopeStack, scopes, html)
+        html += "<span>#{@escapeString(value)}</span>"
+      html = @popScope(scopeStack, html) while scopeStack.length > 0
+      html += '</div>'
+    html += '</pre>'
+    html
+
+  escapeString: (string) ->
+    string.replace /[&"'<> ]/g, (match) ->
+      switch match
+        when '&' then '&amp;'
+        when '"' then '&quot;'
+        when "'" then '&#39;'
+        when '<' then '&lt;'
+        when '>' then '&gt;'
+        when ' ' then '&nbsp;'
+        else match
+
+  updateScopeStack: (scopeStack, desiredScopes, html) ->
+    excessScopes = scopeStack.length - desiredScopes.length
+    if excessScopes > 0
+      html = @popScope(scopeStack, html) while excessScopes--
+
+    # pop until common prefix
+    for i in [scopeStack.length..0]
+      break if _.isEqual(scopeStack[0...i], desiredScopes[0...i])
+      html = @popScope(scopeStack, html)
+
+    # push on top of common prefix until scopeStack is desiredScopes
+    for j in [i...desiredScopes.length]
+      html = @pushScope(scopeStack, desiredScopes[j], html)
+
+    html
+
+  pushScope: (scopeStack, scope, html) ->
+    scopeStack.push(scope)
+    html += "<span class=\"#{scope.replace(/\.+/g, ' ')}\">"
+
+  popScope: (scopeStack, html) ->
+    scopeStack.pop()
+    html += '</span>'

--- a/lib/ui/highlighter.coffee
+++ b/lib/ui/highlighter.coffee
@@ -1,13 +1,9 @@
-# Highlights some `text` according to the specified `grammar`.
-
 # Implementation identical to https://github.com/atom/highlights/blob/master/src/highlights.coffee,
 # but uses an externally provided grammar.
 module.exports =
-  highlight: (text, @grammar) ->
-    _highlightCommon text
-
-  _highlightCommon: (text) ->
-    lineTokens = @grammar.tokenizeLines(text)
+  # Highlights some `text` according to the specified `grammar`.
+  highlight: (text, grammar) ->
+    lineTokens = grammar.tokenizeLines(text)
 
     # Remove trailing newline
     if lineTokens.length > 0

--- a/lib/ui/highlighter.coffee
+++ b/lib/ui/highlighter.coffee
@@ -1,9 +1,10 @@
+# Highlights some `text` according to the specified `grammar`.
 
-# stolen from https://github.com/atom/highlights/blob/master/src/highlights.coffee
-# uses Atoms grammars
+# Implementation identical to https://github.com/atom/highlights/blob/master/src/highlights.coffee,
+# but uses an externally provided grammar.
 module.exports =
-  highlight: (line, @grammar) ->
-    _highlightCommon line
+  highlight: (text, @grammar) ->
+    _highlightCommon text
 
   _highlightCommon: (text) ->
     lineTokens = @grammar.tokenizeLines(text)

--- a/lib/ui/views.coffee
+++ b/lib/ui/views.coffee
@@ -1,4 +1,4 @@
-Highlighter = require './highlighter'
+{highlight} = require './highlighter'
 
 module.exports = views =
   dom: ({tag, attrs, contents}) ->
@@ -59,8 +59,7 @@ module.exports = views =
 
   code: ({text, scope}) ->
     grammar = atom.grammars.grammarForScopeName("source.julia")
-    highlightedHtml = Highlighter.highlight text, grammar
-    @render {type: 'html', content: highlightedHtml}
+    @render {type: 'html', content: highlight text, grammar}
 
   views:
     dom:     (a...) -> views.dom  a...

--- a/lib/ui/views.coffee
+++ b/lib/ui/views.coffee
@@ -1,5 +1,4 @@
-Highlights = require 'highlights'
-highlighter = null
+Highlighter = require './highlighter'
 
 module.exports = views =
   dom: ({tag, attrs, contents}) ->
@@ -59,11 +58,8 @@ module.exports = views =
     view
 
   code: ({text, scope}) ->
-    scope ?= 'source.julia'
-    highlighter ?= new Highlights registry: atom.grammars
-    highlightedHtml = highlighter.highlightSync
-      fileContents: text
-      scopeName: scope
+    grammar = atom.grammars.grammarForScopeName("source.julia")
+    highlightedHtml = Highlighter.highlight text, grammar
     @render {type: 'html', content: highlightedHtml}
 
   views:

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
     "underscore-plus": "*",
-    "atom-package-deps": "*",
-    "highlights": "*"
+    "atom-package-deps": "*"
   },
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
This seems like it may be general enough to have it in Ink, not sure though. 

I'd really like to get rid of the Highlights dependency soon, because it's necessary to patch master on Windows to get it running.