### PR TITLE
Cycler

### DIFF
--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -21,4 +21,4 @@ module.exports =
   boot: ->
     if not @client.isActive()
       @local.start()
-      time "Julia Boot", @client.rpc 'ping'
+      time "Julia Boot", @client.import('ping')()

--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -1,9 +1,10 @@
 {time} = require './misc'
 
 module.exports =
+  IPC:      require './connection/ipc'
   messages: require './connection/messages'
   client:   require './connection/client'
-  local:  require './connection/local'
+  local:    require './connection/local'
   terminal: require './connection/terminal'
 
   activate: ->
@@ -15,7 +16,7 @@ module.exports =
   deactivate: ->
 
   consumeInk: (ink) ->
-    @client.loading = new ink.Loading
+    @IPC.consumeInk ink
 
   boot: ->
     if not @client.isActive()

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -25,7 +25,8 @@ module.exports =
   ipc: new IPC
 
   handle: (a...) -> @ipc.handle a...
-  input: (a...)  -> @ipc.input a...
+  input: (m)  -> @ipc.input m
+  readStream: (s) -> @ipc.readStream s
   import: (a...) -> @ipc.import a...
 
   activate: ->

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -24,10 +24,8 @@ module.exports =
 
   ipc: new IPC
 
-  msg: (a...) -> @ipc.msg a...
-  rpc: (a...) -> @ipc.rpc a...
   handle: (a...) -> @ipc.handle a...
-  input: (a...) -> @ipc.input a...
+  input: (a...)  -> @ipc.input a...
   import: (a...) -> @ipc.import a...
 
   activate: ->
@@ -117,7 +115,7 @@ module.exports =
 
   kill: ->
     if @isConnected() and not @isWorking()
-      @rpc('exit').catch ->
+      @import('exit')().catch ->
     else
       @clientCall 'kill', 'kill'
 

--- a/lib/connection/ipc.coffee
+++ b/lib/connection/ipc.coffee
@@ -1,0 +1,82 @@
+Loading = null
+lwaits = []
+withLoading = (f) -> if Loading? then f() else lwaits.push f
+
+module.exports =
+class IPC
+
+  @consumeInk: (ink) ->
+    Loading = ink.Loading
+    f() for f in lwaits
+
+  constructor: ->
+    withLoading =>
+      @loading = new Loading
+    @handlers = {}
+    @callbacks = {}
+    @queue = []
+    @id = 0
+
+    @handle 'cb', (id, result) =>
+      @callbacks[id]?.resolve result
+      delete @callbacks[id]
+
+    @handle 'cancelCallback', (id, e) =>
+      @callbacks[id].reject e
+
+  handle: (type, f) ->
+    @handlers[type] = f
+
+  writeMsg: -> throw new Error 'msg not implemented'
+
+  msg: (type, args...) -> @writeMsg [type, args...]
+
+  rpc: (type, args...) ->
+    x = new Promise (resolve, reject) =>
+      @id += 1
+      @callbacks[@id] = {resolve, reject}
+      @msg {type, callback: @id}, args...
+    @loading.working()
+    done = => @loading.done()
+    x.then done, done
+    x
+
+  flush: ->
+    @writeMsg msg for msg in @queue
+    @queue = []
+
+  reset: ->
+    @loading.reset()
+    @queue = []
+    cb.reject 'disconnected' for id, cb of @callbacks
+    @callbacks = {}
+
+  input: ([type, args...]) ->
+    if type.constructor == Object
+      {type, callback} = type
+    if @handlers.hasOwnProperty type
+      result = @handlers[type] args...
+      if callback
+        Promise.resolve(result).then (result) =>
+          @msg 'cb', callback, result
+    else
+      console.log "julia-client: unrecognised message #{type}"
+      console.log args
+
+  import: (fs, rpc = true, mod = {}) ->
+    return unless fs?
+    if fs.constructor == String then return @import [fs], rpc, mod
+    if fs.rpc? or fs.msg?
+      mod = {}
+      @import fs.rpc, true,  mod
+      @import fs.msg, false, mod
+    else
+      fs.forEach (f) =>
+        mod[f] = (args...) =>
+          if rpc then @rpc f, args... else @msg f, args...
+    mod
+
+  isWorking: -> @loading.isWorking()
+  onWorking: (f) -> @loading.onWorking f
+  onDone: (f) -> @loading.onDone f
+  onceDone: (f) -> @loading.onceDone f

--- a/lib/connection/ipc.coffee
+++ b/lib/connection/ipc.coffee
@@ -42,8 +42,8 @@ class IPC
       @id += 1
       @callbacks[@id] = {resolve, reject}
       @msg {type, callback: @id}, args...
-    @loading.working()
-    done = => @loading.done()
+    @loading?.working()
+    done = => @loading?.done()
     x.then done, done
     x
 

--- a/lib/connection/ipc.coffee
+++ b/lib/connection/ipc.coffee
@@ -38,14 +38,11 @@ class IPC
   msg: (type, args...) -> @writeMsg [type, args...]
 
   rpc: (type, args...) ->
-    x = new Promise (resolve, reject) =>
+    p = new Promise (resolve, reject) =>
       @id += 1
       @callbacks[@id] = {resolve, reject}
       @msg {type, callback: @id}, args...
-    @loading?.working()
-    done = => @loading?.done()
-    x.then done, done
-    x
+    @loading?.monitor p
 
   flush: ->
     @writeMsg msg for msg in @queue

--- a/lib/connection/ipc.coffee
+++ b/lib/connection/ipc.coffee
@@ -17,15 +17,19 @@ class IPC
     @queue = []
     @id = 0
 
-    @handle 'cb', (id, result) =>
-      @callbacks[id]?.resolve result
-      delete @callbacks[id]
+    @handle
+      cb: (id, result) =>
+        @callbacks[id]?.resolve result
+        delete @callbacks[id]
 
-    @handle 'cancelCallback', (id, e) =>
-      @callbacks[id].reject e
+      cancelCallback: (id, e) =>
+        @callbacks[id].reject e
 
   handle: (type, f) ->
-    @handlers[type] = f
+    if f?
+      @handlers[type] = f
+    else
+      @handle t, f for t, f of type
 
   writeMsg: -> throw new Error 'msg not implemented'
 
@@ -65,7 +69,7 @@ class IPC
 
   import: (fs, rpc = true, mod = {}) ->
     return unless fs?
-    if fs.constructor == String then return @import [fs], rpc, mod
+    if fs.constructor == String then return @import([fs], rpc, mod)[fs]
     if fs.rpc? or fs.msg?
       mod = {}
       @import fs.rpc, true,  mod

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -3,10 +3,15 @@ messages = require './messages'
 client = require './client'
 
 basic = require './process/basic'
+cycler = require './process/cycler'
 
 module.exports =
 
   activate: ->
+    paths.getVersion()
+      .then ->
+        cycler.start paths.jlpath(), client.clargs()
+      .catch ->
 
   buffer: (f) ->
     buffer = ['']
@@ -59,4 +64,4 @@ module.exports =
         throw e
 
   spawnJulia: (path, args) ->
-    basic.get path, args
+    cycler.get path, args

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -9,6 +9,7 @@ cycler = require './process/cycler'
 server = require './process/server'
 
 module.exports =
+  server: server
 
   activate: ->
     paths.getVersion()

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -15,16 +15,6 @@ module.exports =
         cycler.start paths.jlpath(), client.clargs()
       .catch ->
 
-  buffer: (f) ->
-    buffer = ['']
-    (data) ->
-      str = data.toString()
-      lines = str.split '\n'
-      buffer[0] += lines.shift()
-      buffer.push lines...
-      while buffer.length > 1
-        f buffer.shift()
-
   monitor: (proc) ->
     proc.onExit (code, signal) ->
       msg = "Julia has stopped"
@@ -42,7 +32,7 @@ module.exports =
 
   connect: (proc, sock) ->
     proc.message = (m) -> sock.write JSON.stringify m
-    sock.on 'data', @buffer (m) -> client.input JSON.parse m
+    client.readStream sock
     sock.on 'end', -> client.disconnected()
     client.connected proc
 

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -4,15 +4,16 @@ client = require './client'
 
 cd = client.import 'cd', false
 
-basic = require './process/basic'
+basic  = require './process/basic'
 cycler = require './process/cycler'
+server = require './process/server'
 
 module.exports =
 
   activate: ->
     paths.getVersion()
       .then ->
-        cycler.start paths.jlpath(), client.clargs()
+        server.start paths.jlpath(), client.clargs()
       .catch ->
 
   monitor: (proc) ->
@@ -59,4 +60,4 @@ module.exports =
         throw e
 
   spawnJulia: (path, args) ->
-    cycler.get path, args
+    server.get path, args

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -32,8 +32,11 @@ module.exports =
       else
         msg += "."
       client.stderr msg
-    proc.stdout.on 'data', (data) -> client.stdout data.toString()
-    proc.stderr.on 'data', (data) -> client.stderr data.toString()
+    out = (data) -> client.stdout data.toString()
+    err = (data) -> client.stderr data.toString()
+    proc.flush? out, err
+    proc.onStdout out
+    proc.onStderr err
 
   connect: (proc, sock) ->
     proc.message = (m) -> sock.write JSON.stringify m

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -2,6 +2,8 @@
 messages = require './messages'
 client = require './client'
 
+cd = client.import 'cd', false
+
 basic = require './process/basic'
 cycler = require './process/cycler'
 
@@ -47,7 +49,7 @@ module.exports =
   start: ->
     [path, args] = [paths.jlpath(), client.clargs()]
     client.booting()
-    paths.projectDir().then (dir) -> client.msg 'cd', dir
+    paths.projectDir().then (dir) -> cd dir
     check = paths.getVersion()
 
     check.catch (err) =>

--- a/lib/connection/messages.coffee
+++ b/lib/connection/messages.coffee
@@ -45,7 +45,7 @@ module.exports =
         dismissable: true
       @openConsole()
 
-    client.handle 'welcome', =>
+    client.handle welcome: =>
       @note?.dismiss()
       atom.notifications.addSuccess "Welcome to Juno!",
         detail: """
@@ -66,7 +66,7 @@ module.exports =
       #{path}
 
       This path can be changed in the settings.
-      
+
       """ + if details isnt ''
         """
         Details:

--- a/lib/connection/process/basic.coffee
+++ b/lib/connection/process/basic.coffee
@@ -15,12 +15,13 @@ module.exports =
         resolve port
 
   createProc: (proc, obj = {}) ->
+    obj.proc ?= proc
     obj.onExit = (f) ->
       proc.on 'exit', f
       {dispose: -> proc.removeListener('exit', f)}
-    obj.stdin ?= proc.stdin
-    obj.stdout ?= proc.stdout
-    obj.stderr ?= proc.stderr
+    obj.stdin ?= (data) -> proc.stdin.write data
+    obj.onStdout ?= (f) -> proc.stdout.on 'data', f
+    obj.onStderr ?= (f) -> proc.stderr.on 'data', f
     obj
 
   socket: (proc, port) ->

--- a/lib/connection/process/boot.js
+++ b/lib/connection/process/boot.js
@@ -1,0 +1,22 @@
+process.on('uncaughtException', function (err) {
+  if (process.connected) {
+    process.send({type: 'error', message: err.message, stack: err.stack});
+  }
+  process.exit(1);
+});
+
+process.on('unhandledRejection', function (err) {
+  if (process.connected) {
+    if (err instanceof Error) {
+      process.send({type: 'rejection', message: err.message, stack: err.stack});
+    } else {
+      process.send({type: 'rejection', err});
+    }
+  }
+});
+
+require('coffee-script/register');
+
+const server = require('./server');
+
+server.serve();

--- a/lib/connection/process/cycler.coffee
+++ b/lib/connection/process/cycler.coffee
@@ -1,0 +1,55 @@
+{isEqual} = require 'underscore-plus'
+basic = require './basic'
+
+module.exports =
+
+  cacheLength: 1
+
+  procs: {}
+
+  key: (path, args) -> [path, args...].join ' '
+
+  cache: (path, args) -> @procs[@key(path, args)] ?= []
+
+  removeFromCache: (path, args, obj) ->
+    key = @key path, args
+    @procs[key] = @procs[key].filter (x) -> x != obj
+
+  toCache: (path, args, proc) ->
+    @cache(path, args).push proc
+
+  fromCache: (path, args) ->
+    ps = @cache path, args
+    p = ps.shift()
+    if p == @booting then delete @booting
+    @start path, args
+    p?.proc
+
+  start: (path, args) ->
+    if @booting
+      @booting.then (obj) =>
+        return if isEqual([obj.path, obj.args], [path, args])
+        obj.proc.kill()
+        obj.proc.socket.catch (e) =>
+          @start path, args
+    else if @cache(path, args).length < @cacheLength
+      @booting = basic.get(path, args).then (proc) =>
+        obj = {path, args, proc: proc}
+        @toCache path, args, obj
+        proc.socket
+          .then =>
+            delete @booting
+            @start path, args
+          .catch (e) =>
+            delete @booting
+            @removeFromCache path, args, obj
+            Promise.reject e
+        obj
+    return
+
+  get: (path, args) ->
+    @start path, args
+    if (proc = @fromCache path, args)
+      Promise.resolve proc
+    else
+      basic.get path, args

--- a/lib/connection/process/cycler.coffee
+++ b/lib/connection/process/cycler.coffee
@@ -2,6 +2,8 @@
 {hook} = require '../../misc'
 basic = require './basic'
 
+IPC = require '../ipc'
+
 module.exports =
 
   cacheLength: 1
@@ -17,14 +19,18 @@ module.exports =
     @procs[key] = @procs[key].filter (x) -> x != obj
 
   toCache: (path, args, proc) ->
+    proc.cached = true
     @cache(path, args).push proc
 
   fromCache: (path, args) ->
     ps = @cache path, args
     p = ps.shift()
-    if p == @booting then delete @booting
-    @start path, args
-    p?.proc
+    return unless p?
+    p.cached = false
+    p.init.then =>
+      if p == @booting then delete @booting
+      @start path, args
+      p.proc
 
   start: (path, args) ->
     if @booting
@@ -37,6 +43,7 @@ module.exports =
       @booting = basic.get(path, args).then (proc) =>
         obj = {path, args, proc: proc}
         @monitor obj
+        @warmup obj
         @toCache path, args, obj
         proc.socket
           .then =>
@@ -45,7 +52,6 @@ module.exports =
           .catch (e) =>
             delete @booting
             @removeFromCache path, args, obj
-            Promise.reject e
         obj
     return
 
@@ -58,9 +64,27 @@ module.exports =
         (if type == 'stdout' then out else err) data
       delete obj.events
 
+  boot: (ipc) -> ipc.rpc 'ping'
+  console: (ipc) -> ipc.rpc 'evalrepl', {code: 'Void()'}
+  editor: (ipc) -> ipc.rpc 'eval', {text: '2+2', mod: 'Main', line: 1, path: 'untitled'}
+  completions: (ipc) -> ipc.rpc 'cacheCompletions', 'Main'
+
+  warmup: (obj) ->
+    obj.init = Promise.resolve()
+    obj.proc.socket
+      .then (sock) =>
+        return unless obj.cached
+        ipc = new IPC sock
+        [@boot, @console, @editor, @completions].forEach (f) ->
+          obj.init = obj.init.then ->
+            if obj.cached then f ipc
+        obj.init = obj.init
+          .catch (err) -> console.warn 'julia warmup error:', err
+          .then -> ipc.unreadStream()
+        return
+      .catch ->
+
   get: (path, args) ->
     @start path, args
-    if (proc = @fromCache path, args)
-      Promise.resolve proc
-    else
-      basic.get path, args
+    if (proc = @fromCache path, args) then proc
+    else basic.get path, args

--- a/lib/connection/process/server.coffee
+++ b/lib/connection/process/server.coffee
@@ -81,6 +81,8 @@ module.exports =
         onStdout: (f) -> stdout.on 'data', f
         onStderr: (f) -> stderr.on 'data', f
         flush: (out, err) -> cycler.flush events, out, err
+        interrupt: => @server.interrupt id
+        kill:      => @server.kill id
         socket: @getSocket id
         onExit: (f) =>
           Promise.race [@server.onExit(id),
@@ -135,6 +137,8 @@ module.exports =
     onBoot: (id) => @ps[id].socket.then -> true
     onExit: (id) => new Promise (resolve) => @ps[id].onExit resolve
     onAttach: (id) => @ps[id].attached.then ->
+    interrupt: (id) => @ps[id].interrupt()
+    kill: (id) => @ps[id].kill()
 
     events: (id) =>
       proc = @ps[id]
@@ -161,6 +165,7 @@ module.exports =
   mutualClose: (a, b) ->
     [[a, b], [b, a]].forEach ([from, to]) ->
       from.on 'end', -> to.end()
+      from.on 'error', -> to.end()
 
   streamHandlers: (ipc) ->
     ['socket', 'stdout', 'stderr', 'stdin'].forEach (stream) =>

--- a/lib/connection/process/server.coffee
+++ b/lib/connection/process/server.coffee
@@ -1,0 +1,167 @@
+os = require 'os'
+net = require 'net'
+path = require 'path'
+fs = require 'fs'
+child_process = require 'child_process'
+
+IPC = require '../ipc'
+basic = require './basic'
+cycler = require './cycler'
+
+module.exports =
+
+  socketPath: (name) ->
+    if process.platform is 'win32'
+      "\\\\.\\pipe\\#{name}"
+    else
+      path.join(os.tmpdir(), "#{name}.sock")
+
+  removeSocket: (name) ->
+    new Promise (resolve, reject) =>
+      p = @socketPath name
+      fs.exists p, (exists) ->
+        if not exists then return resolve()
+        fs.unlink p, (err) ->
+          if err then reject(err) else resolve()
+
+  # Client
+
+  boot: ->
+    @removeSocket('juno-server').then =>
+      new Promise (resolve, reject) =>
+        console.log 'booting julia server'
+        proc = child_process.fork path.join(__dirname, 'boot.js')
+        proc.on 'message', (x) ->
+          if x == 'ready' then resolve()
+          else console.log 'julia server:', x
+        proc.on 'exit', (code, status) ->
+          console.warn 'julia server:', [code, status]
+          reject([code, status])
+
+  connect: ->
+    new Promise (resolve, reject) =>
+      client = net.connect @socketPath('juno-server'), =>
+        ipc = new IPC client
+        resolve ipc.import Object.keys(@serverAPI()), true, {ipc}
+      client.on 'error', (err) ->
+        reject err
+
+  activate: ->
+    return Promise.resolve(@server) if @server?
+    @connect()
+      .catch (err) =>
+        if err.code in ['ECONNREFUSED', 'ENOENT']
+          @boot().then => @connect()
+        else Promise.reject err
+      .then (@server) =>
+        @server.ipc.stream.on 'end', => delete @server
+        @server
+
+  getStream: (id, s) ->
+    @connect().then ({ipc}) ->
+      sock = ipc.stream
+      ipc.msg s, id
+      ipc.unreadStream()
+      sock
+
+  getStreams: (id) -> Promise.all (@getStream id, s for s in ['stdin', 'stdout', 'stderr'])
+
+  getSocket: (id) ->
+    @server.onBoot(id).then =>
+      @getStream id, 'socket'
+        .then (sock) ->
+          window.sock = sock
+          sock
+
+  get: (path, args) ->
+    @activate()
+      .then => @server.get path, args
+      .then (id) => Promise.all [id, @getStreams(id), @server.events(id)]
+      .then ([id, [stdin, stdout, stderr], events]) =>
+        stdin: (data) -> stdin.write data
+        onStdout: (f) -> stdout.on 'data', f
+        onStderr: (f) -> stderr.on 'data', f
+        flush: (out, err) -> cycler.flush events, out, err
+        socket: @getSocket id
+        onExit: (f) =>
+          Promise.race [@server.onExit(id),
+                        new Promise (resolve) => @server.ipc.stream.on 'end', resolve]
+            .then f
+
+  start: (path, args) ->
+    @activate()
+      .then => @server.start path, args
+
+  # Server
+
+  initIPC: (sock) ->
+    # TODO: exit once all clients close
+    ipc = new IPC sock
+    ipc.handle @serverAPI()
+    @streamHandlers ipc
+    ipc
+
+  serve: ->
+    cycler.cacheLength = 3
+    @server = net.createServer (sock) =>
+      @initIPC sock
+    @server.listen @socketPath('juno-server'), ->
+      process.send 'ready'
+    @server.on 'error', (err) ->
+      process.send err
+      process.exit()
+
+  pid: 0
+  ps: {}
+
+  serverAPI: ->
+
+    get: (path, args) =>
+      cycler.get(path, args)
+        .then (p) =>
+          p.id = (@pid += 1)
+          @ps[p.id] = p
+          p.id
+
+    start: (path, args) -> cycler.start path, args, false
+
+    onBoot: (id) => @ps[id].socket.then -> true
+    onExit: (id) => new Promise (resolve) => @ps[id].onExit resolve
+
+    events: (id) =>
+      proc = @ps[id]
+      events = proc.events ? []
+      delete proc.events
+      for event in events
+        event.data = event.data?.toString()
+      events
+
+    exit: =>
+      cycler.reset()
+      for id, proc of @ps
+        proc.kill()
+      process.exit()
+
+  crossStreams: (a, b) ->
+    [[a, b], [b, a]].forEach ([from, to]) ->
+      from.on 'data', (data) ->
+        try to.write data
+        catch e
+          if process.connected
+            process.send {type: 'error', message: e.message, stack: e.stack, data: data.toString()}
+
+  mutualClose: (a, b) ->
+    [[a, b], [b, a]].forEach ([from, to]) ->
+      from.on 'end', -> to.end()
+
+  streamHandlers: (ipc) ->
+    ['socket', 'stdout', 'stderr', 'stdin'].forEach (stream) =>
+      ipc.handle stream, (id) =>
+        proc = @ps[id]
+        sock = ipc.stream
+        ipc.unreadStream()
+        source = if stream == 'socket' then proc.socket else proc.proc[stream]
+        Promise.resolve(source).then (source) =>
+          @crossStreams source, sock
+          if stream == 'socket' then @mutualClose source, sock
+          else sock.on 'end', -> proc.kill()

--- a/lib/connection/process/server.coffee
+++ b/lib/connection/process/server.coffee
@@ -92,6 +92,11 @@ module.exports =
     @activate()
       .then => @server.start path, args
 
+  reset: ->
+    @connect()
+      .catch -> atom.notifications.addInfo 'No server running.'
+      .then (server) -> server.exit()
+
   # Server
 
   initIPC: (sock) ->

--- a/lib/connection/process/server.coffee
+++ b/lib/connection/process/server.coffee
@@ -29,7 +29,7 @@ module.exports =
   boot: ->
     @removeSocket('juno-server').then =>
       new Promise (resolve, reject) =>
-        console.log 'booting julia server'
+        console.info 'booting julia server'
         proc = child_process.fork path.join(__dirname, 'boot.js')
         proc.on 'message', (x) ->
           if x == 'ready' then resolve()
@@ -94,8 +94,8 @@ module.exports =
 
   reset: ->
     @connect()
+      .then (server) -> server.exit().catch ->
       .catch -> atom.notifications.addInfo 'No server running.'
-      .then (server) -> server.exit()
 
   # Server
 

--- a/lib/connection/process/server.coffee
+++ b/lib/connection/process/server.coffee
@@ -30,7 +30,7 @@ module.exports =
     @removeSocket('juno-server').then =>
       new Promise (resolve, reject) =>
         console.info 'booting julia server'
-        proc = child_process.fork path.join(__dirname, 'boot.js')
+        proc = child_process.fork path.join(__dirname, 'boot.js'), detached: true
         proc.on 'message', (x) ->
           if x == 'ready' then resolve()
           else console.log 'julia server:', x
@@ -55,6 +55,7 @@ module.exports =
         else Promise.reject err
       .then (@server) =>
         @server.ipc.stream.on 'end', => delete @server
+        @server.setPS basic.wrapperEnabled()
         @server
 
   getStream: (id, s) ->
@@ -106,6 +107,7 @@ module.exports =
 
   serve: ->
     cycler.cacheLength = 3
+    basic.wrapperEnabled = -> true
     @server = net.createServer (sock) =>
       @initIPC sock
     @server.listen @socketPath('juno-server'), ->
@@ -118,6 +120,8 @@ module.exports =
   ps: {}
 
   serverAPI: ->
+
+    setPS: (enabled) -> basic.wrapperEnabled = -> enabled
 
     get: (path, args) =>
       cycler.get(path, args)

--- a/lib/misc.coffee
+++ b/lib/misc.coffee
@@ -14,3 +14,11 @@ module.exports =
   hook: (obj, method, f) ->
     souper = obj[method].bind obj
     obj[method] = (a...) -> f souper, a...
+
+  mutex: ->
+    wait = Promise.resolve()
+    lock = (f) ->
+      current = wait
+      release = null
+      wait = new Promise((resolve) -> release = resolve).catch ->
+      current.then -> f release

--- a/lib/misc.coffee
+++ b/lib/misc.coffee
@@ -10,3 +10,7 @@ module.exports =
     p.then (result) ->
       console.log "#{desc}: #{(s()-t).toFixed(2)}s"
       result
+
+  hook: (obj, method, f) ->
+    souper = obj[method].bind obj
+    obj[method] = (a...) -> f souper, a...

--- a/lib/misc.coffee
+++ b/lib/misc.coffee
@@ -7,9 +7,9 @@ module.exports =
   time: (desc, p) ->
     s = -> new Date().getTime()/1000
     t = s()
-    p.then (result) ->
-      console.log "#{desc}: #{(s()-t).toFixed(2)}s"
-      result
+    p.then -> console.log "#{desc}: #{(s()-t).toFixed(2)}s"
+      .catch ->
+    p
 
   hook: (obj, method, f) ->
     souper = obj[method].bind obj

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -66,6 +66,7 @@ module.exports =
       'julia-client:start-julia': -> disrequireClient 'boot Julia', -> boot()
       'julia-client:kill-julia': => requireClient 'kill Julia', -> juno.connection.client.kill()
       'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
+      'julia-client:reset-julia-server': -> juno.connection.local.server.reset()
       'julia-client:open-console': => @withInk -> juno.runtime.console.open()
       "julia-client:clear-console": => juno.runtime.console.reset()
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -3,10 +3,6 @@ shell =                 require 'shell'
 
 module.exports =
   activate: (juno) ->
-
-    if atom.config.get("julia-client.launchOnStartup")
-      @withInk -> juno.connection.boot()
-
     requireClient    = (a, f) -> juno.connection.client.require a, f
     disrequireClient = (a, f) -> juno.connection.client.disrequire a, f
     boot = -> juno.connection.boot()

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -43,7 +43,7 @@ module.exports =
         requireClient 'reset the workspace', ->
           editor = atom.workspace.getActiveTextEditor()
           atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
-          juno.connection.client.rpc('clear-workspace')
+          juno.connection.client.import('clear-workspace')()
       'julia:select-block': =>
         juno.misc.blocks.select()
       'julia-client:send-to-stdin': (e) =>

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -1,11 +1,6 @@
 {local: proc, terminal} = require '../connection'
 
 config =
-  launchOnStartup:
-    type: 'boolean'
-    default: false
-    description: 'Launch a Julia client when Atom starts.'
-    order: 1
   juliaPath:
     type: 'string'
     default: 'julia'

--- a/lib/runtime/console.coffee
+++ b/lib/runtime/console.coffee
@@ -6,7 +6,7 @@
 
 modules = require './modules'
 
-{evalrepl} = client.import 'evalrepl'
+evalrepl = client.import 'evalrepl'
 
 module.exports =
   activate: ->
@@ -17,18 +17,19 @@ module.exports =
 
     @subs = new CompositeDisposable
 
-    client.handle 'info', (msg) =>
-      @c.info msg
+    client.handle
+      info: (msg) =>
+        @c.info msg
 
-    client.handle 'result', (result) =>
-      view = if result.type == 'error' then result.view else result
-      view = views.render(view)
-      if result.type isnt 'error'
-        views.ink.tree.toggle view
-      @c.result view,
-        error: result.type == 'error'
+      result: (result) =>
+        view = if result.type == 'error' then result.view else result
+        view = views.render(view)
+        if result.type isnt 'error'
+          views.ink.tree.toggle view
+        @c.result view,
+          error: result.type == 'error'
 
-    client.handle 'input', => @input()
+      input: => @input()
 
     client.onStdout (s) => @stdout s
     client.onStderr (s) => @stderr s

--- a/lib/runtime/debugger.coffee
+++ b/lib/runtime/debugger.coffee
@@ -11,8 +11,9 @@ breakpoints = null
 
 module.exports =
   activate: ->
-    client.handle 'debugmode', (state) => @debugmode state
-    client.handle 'stepto', (file, line, text) => @stepto file, line, text
+    client.handle
+      debugmode: (state) => @debugmode state
+      stepto: (file, line, text) => @stepto file, line, text
 
     client.onDisconnected => @debugmode false
 

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -54,12 +54,12 @@ module.exports =
   gotoSymbol: ->
     @withCurrentContext ({editor, mod}) =>
       words.withWord editor, (word, range) =>
-        client.rpc("methods", {word: word, mod: mod}).then (result) => # 149
+        client.import("methods")({word: word, mod: mod}).then (result) => # 149
 
   toggleDocs: ->
     @withCurrentContext ({editor, mod}) =>
       words.withWord editor, (word, range) =>
-        client.rpc("docs", {word: word, mod: mod}).then (result) =>
+        client.import("docs")({word: word, mod: mod}).then (result) =>
           if result.error then return
           d = new @ink.InlineDoc editor, range,
             content: views.render result

--- a/lib/runtime/frontend.coffee
+++ b/lib/runtime/frontend.coffee
@@ -13,25 +13,26 @@ module.exports =
   windows: {}
 
   activate: ->
-    client.handle 'select', (items) -> selector.show items
+    client.handle select: (items) -> selector.show items
 
     # Blink APIs
 
-    client.handle 'createWindow', (opts) =>
-      w = new BrowserWindow opts
-      if opts.url?
-        w.loadUrl opts.url
-      w.setMenu(null)
-      wid = w.id
-      @windows[wid] = w
-      w.on 'close', => delete @windows[wid]
-      return wid
+    client.handle
+      createWindow: (opts) =>
+        w = new BrowserWindow opts
+        if opts.url?
+          w.loadUrl opts.url
+        w.setMenu(null)
+        wid = w.id
+        @windows[wid] = w
+        w.on 'close', => delete @windows[wid]
+        return wid
 
-    client.handle 'withWin', (id, code) =>
-      @evalwith @windows[id], code
+      withWin: (id, code) =>
+        @evalwith @windows[id], code
 
-    client.handle 'winActive', (id) =>
-      @windows.hasOwnProperty id
+      winActive: (id) =>
+        @windows.hasOwnProperty id
 
     client.onDisconnected =>
       for id, win of @windows

--- a/lib/runtime/plots.coffee
+++ b/lib/runtime/plots.coffee
@@ -3,8 +3,9 @@
 
 module.exports =
   activate: ->
-    client.handle 'plot', (x) => @show x
-    client.handle 'plotsize', => @plotSize()
+    client.handle
+      plot: (x) => @show x
+      plotsize: => @plotSize()
     @create()
 
   create: ->

--- a/lib/runtime/workspace.coffee
+++ b/lib/runtime/workspace.coffee
@@ -3,7 +3,7 @@
 {views} = require '../ui'
 {client} = require '../connection'
 
-{workspace} = client.import 'workspace'
+workspace = client.import 'workspace'
 
 module.exports =
   activate: ->

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -10,7 +10,7 @@ module.exports =
     @client.onDisconnected =>
       @ink?.Result.invalidateAll()
 
-    @client.handle 'progress', (p) =>
+    @client.handle progress: (p) =>
       @progress?.progress = p
 
   consumeInk: (@ink) ->

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
     "underscore-plus": "*",
-    "atom-package-deps": "*"
+    "atom-package-deps": "*",
+    "coffee-script": "*"
   },
   "consumedServices": {
     "status-bar": {

--- a/spec/client.coffee
+++ b/spec/client.coffee
@@ -71,14 +71,14 @@ describe "managing the client", ->
             expect(result).toBe(Math.pow(x, 2))
 
     it "can rpc into the frontend", ->
-      client.handle 'test', (x) -> Math.pow(x, 2)
+      client.handle test: (x) -> Math.pow(x, 2)
       [1..10].forEach (x) ->
         waitsForPromise ->
           evalsimple("@rpc test(#{x})").then (result) ->
             expect(result).toBe(Math.pow(x, 2))
 
     it "can retrieve promise values from the frontend", ->
-      client.handle 'test', (x) ->
+      client.handle test: (x) ->
         Promise.resolve x
       waitsForPromise ->
         evalsimple("@rpc test(2)").then (x) ->

--- a/spec/eval.coffee
+++ b/spec/eval.coffee
@@ -27,7 +27,7 @@ describe 'in an editor', ->
       editor.setGrammar(atom.grammars.grammarForScopeName('source.julia'))
 
   it 'can evaluate code', ->
-    client.handle 'test', (spy = jasmine.createSpy())
+    client.handle test: (spy = jasmine.createSpy())
     editor.insertText 'Atom.@rpc test()'
     command editor, 'julia-client:run-block'
     waitsForClient()


### PR DESCRIPTION
Between Julia 0.4 and 0.5 boot time has gone up from ~5s to ~40s. This PR resolves this in several components.

`ipc.coffee` factors out our mechanism for remote procedure calls, which was previously tied to the Julia client. This is simply so that we can create an RPC communication channel with other kinds of server (and is used below).

`cycler.coffee` takes advantage of opportunities for concurrency between the user and the computer. If the user is working with an already-booted instance of Julia, we can use that time to boot up the *next* instance preemptively. This reduces boot time to sub-second. It gets even better; if the process finishes booting but still isn't needed, we can spend some time warming it up (by simulating the execution of common commands) and make it even more responsive.

`server.coffee` makes this even more ~~complicated~~ advanced by doing the above in an entirely separate process. This means startup time is saved even when opening fresh atom windows. It should also enable a much faster feedback loop when writing tests, which currently takes several minutes due to the need to boot multiple clients.

This has been working well for me and makes things feel much snappier and nicer, but given the extra surface area for issues we should probably roll it out gradually. Feedback and testing are of course appreciated.