### PR TITLE
Don't warn on `kill` if there's no client

### DIFF
--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -101,10 +101,13 @@ module.exports =
       @clientCall 'interrupts', 'interrupt'
 
   kill: ->
-    if @isActive() and not @isWorking()
-      @import('exit')().catch ->
+    if @isActive()
+      if not @isWorking()
+        @import('exit')().catch ->
+      else
+        @clientCall 'kill', 'kill'
     else
-      @clientCall 'kill', 'kill'
+      @ipc.reset()
 
   clargs: ->
     {precompiled, optimisationLevel, deprecationWarnings} =

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -60,7 +60,7 @@ module.exports =
     @subs.add atom.commands.add 'atom-workspace',
       'julia-client:open-a-repl': -> juno.connection.terminal.repl()
       'julia-client:start-julia': -> disrequireClient 'boot Julia', -> boot()
-      'julia-client:kill-julia': => requireClient 'kill Julia', -> juno.connection.client.kill()
+      'julia-client:kill-julia': -> juno.connection.client.kill()
       'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
       'julia-client:reset-julia-server': -> juno.connection.local.server.reset()
       'julia-client:connect-to-local-port': -> disrequireClient -> juno.connection.terminal.connectPortUI()


### PR DESCRIPTION
This warning served a debugging purpose at one point but I don't think it's necessary now, given that killing is idempotent anyway. It's like having a warning "this file has already been saved".

I also added an ipc reset on kill if there's no active client. Strictly speaking, having work without a client is a state we should avoid getting into, but this is a better behaviour if we do reach that state.