### PR TITLE
Connect to external processes

### DIFF
--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -61,6 +61,11 @@ module.exports =
   onAttached: (cb) -> @emitter.on 'attached', cb
   onDetached: (cb) -> @emitter.on 'detached', cb
 
+  onceAttached: (cb) ->
+    f = @onAttached (args...) ->
+      f.dispose()
+      cb.call this, args...
+
   isActive: -> @conn?
 
   attach: (@conn) ->

--- a/lib/connection/messages.coffee
+++ b/lib/connection/messages.coffee
@@ -1,4 +1,5 @@
 client = require './client'
+tcp = require './process/tcp'
 
 module.exports =
   activate: ->
@@ -75,3 +76,19 @@ module.exports =
       else
         ""
       dismissable: true
+
+  connectExternal: ->
+    tcp.listen().then (port) ->
+      msg = atom.notifications.addInfo "Connect an external process",
+        detail: """
+        To connect a Julia process running in the terminal,
+        run the command:
+
+            using Juno
+            Juno.connect(#{port})
+        """
+        dismissable: true
+      client.onceAttached ->
+        if not msg.isDismissed()
+          msg.dismiss()
+          atom.notifications.addSuccess "Julia is connected."

--- a/lib/connection/messages.coffee
+++ b/lib/connection/messages.coffee
@@ -79,15 +79,16 @@ module.exports =
 
   connectExternal: ->
     tcp.listen().then (port) ->
+      code = "using Juno; Juno.connect(#{port})"
       msg = atom.notifications.addInfo "Connect an external process",
         detail: """
         To connect a Julia process running in the terminal,
         run the command:
-
-            using Juno
-            Juno.connect(#{port})
+        -
+            #{code}
         """
         dismissable: true
+        buttons: [{text: 'Copy', onDidClick: -> atom.clipboard.write code}]
       client.onceAttached ->
         if not msg.isDismissed()
           msg.dismiss()

--- a/lib/connection/terminal.coffee
+++ b/lib/connection/terminal.coffee
@@ -33,20 +33,3 @@ module.exports =
       'x-terminal-emulator -e'
 
   repl: -> @term "#{@escpath paths.jlpath()}"
-
-  connectPort: (port) ->
-    sock = net.connect port
-    client.readStream sock
-    client.attach message: (m) -> sock.write JSON.stringify m
-    sock.on 'end', -> client.detach()
-    sock.on 'error', -> client.detach()
-
-  connectPortUI: ->
-    {console: cons} = require '../runtime'
-    cons.info 'Please enter a port:'
-    cons.input().then (input) =>
-      port = parseInt input
-      @connectPort port
-      client.import('ping')()
-        .then -> atom.notifications.addSuccess "Connected to Julia on #{port}"
-        .catch -> atom.notifications.addError "Couldn't connect to Julia on #{port}"

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -63,7 +63,6 @@ module.exports =
       'julia-client:kill-julia': -> juno.connection.client.kill()
       'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
       'julia-client:reset-julia-server': -> juno.connection.local.server.reset()
-      'julia-client:connect-to-local-port': -> disrequireClient -> juno.connection.terminal.connectPortUI()
       'julia-client:open-console': => @withInk -> juno.runtime.console.open()
       "julia-client:clear-console": => juno.runtime.console.reset()
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -63,6 +63,7 @@ module.exports =
       'julia-client:kill-julia': -> juno.connection.client.kill()
       'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
       'julia-client:reset-julia-server': -> juno.connection.local.server.reset()
+      'julia-client:connnect-external-process': -> juno.connection.messages.connectExternal()
       'julia-client:open-console': => @withInk -> juno.runtime.console.open()
       "julia-client:clear-console": => juno.runtime.console.reset()
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -63,7 +63,7 @@ module.exports =
       'julia-client:kill-julia': -> juno.connection.client.kill()
       'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
       'julia-client:reset-julia-server': -> juno.connection.local.server.reset()
-      'julia-client:connnect-external-process': -> juno.connection.messages.connectExternal()
+      'julia-client:connnect-external-process': -> disrequireClient -> juno.connection.messages.connectExternal()
       'julia-client:open-console': => @withInk -> juno.runtime.console.open()
       "julia-client:clear-console": => juno.runtime.console.reset()
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()


### PR DESCRIPTION
This adds a simple (but much nicer than before) UI for connecting from an external Julia process, e.g. in the terminal or IJulia.