### PR TITLE
WIP: Breakpoint UI

### DIFF
--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -81,8 +81,9 @@ module.exports =
       "julia-client:clear-console": => juno.runtime.console.reset()
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()
       'julia-client:open-workspace': => @withInk -> juno.runtime.workspace.open()
-      'julia-client:settings': ->
-        atom.workspace.open('atom://config/packages/julia-client')
+      'julia-client:settings': -> atom.workspace.open('atom://config/packages/julia-client')
+      'julia-debug:clear-all-breakpoints': => juno.runtime.debugger.clearall()
+      'julia-debug:get-all-breakpoints': => juno.runtime.debugger.getBPs()
       'julia-debug:step-to-next-line': => juno.runtime.debugger.nextline()
       'julia-debug:step-to-next-expression': => juno.runtime.debugger.stepexpr()
       'julia-debug:step-into-function': => juno.runtime.debugger.stepin()

--- a/lib/runtime/completions.coffee
+++ b/lib/runtime/completions.coffee
@@ -15,6 +15,9 @@ module.exports =
   filterSuggestions: true
   excludeLowerPriority: false
 
+  sleep: (n) ->
+    new Promise((resolve) -> setTimeout(resolve, n*1000))
+
   getTextEditorSelector: -> 'atom-text-editor'
 
   rawCompletions: ({editor, bufferPosition: {row, column}, activatedManually}) ->
@@ -41,9 +44,10 @@ module.exports =
 
   getSuggestions: (data) ->
     return [] unless client.isActive() and @validScope data.scopeDescriptor
-    @rawCompletions(data).then ({completions, prefix, mod}) =>
+    cs = @rawCompletions(data).then ({completions, prefix, mod}) =>
       return @fromCache mod, prefix if not completions?
       @processCompletions completions, prefix
+    Promise.race([cs, @sleep(1).then(->[])])
 
   cache: {}
 

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -74,7 +74,7 @@ function bp(file, line) {
   client.require(async () => {
     let bp = breakpoints.toggle(file, line)
     await loadgallium()
-    let response = await ((bp ? addsourcebp : removesourcebp)(file, line))
+    let response = await ((bp ? addsourcebp : removesourcebp)(file, line+1))
     console.log(response)
   })
 }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -71,18 +71,12 @@ function bufferForFile(file) {
 
 function bp(file, line) {
   // loadgallium().then(() => {
-    let i = breakpoints.breakpoints.findIndex(bp => bp.file === file && bp.line === line)
-    if (i > -1) {
-      let bp = breakpoints.breakpoints[i]
-      bp.destroy()
-    } else {
-      breakpoints.add(file, line, 'active')
-    }
+    breakpoints.toggle(file, line)
   // })
 }
 
 export function clearall() {
-  breakpoints.breakpoints.forEach(bp => bp.destroy())
+  breakpoints.clear()
   if (client.isActive()) clearbps()
 }
 

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -6,8 +6,10 @@ import { client } from '../connection'
 
 import workspace from './workspace'
 
-let {nextline, stepin, finish, stepexpr} =
-  client.import(['nextline', 'stepin', 'finish', 'stepexpr'])
+let {nextline, stepin, finish, stepexpr, clearbps} =
+  client.import(['nextline', 'stepin', 'finish', 'stepexpr', 'clearbps'])
+
+let {togglebp, getbps} = client.import({rpc: ['togglebp', 'getbps']})
 
 let ink, active, stepper, subs
 
@@ -60,14 +62,26 @@ export function stepexpr() { requireDebugging(() => stepexpr()) }
 let breakpoints = []
 
 function bp(file, line) {
-  let existing
-  if ((existing = ink.breakpoints.get(file, line, breakpoints)[0]) != null) {
-    breakpoints = breakpoints.filter(x => x !== existing)
-    existing.destroy()
-  } else {
-    let thebp = ink.breakpoints.add(file, line)
-    breakpoints.push(thebp)
-  }
+  togglebp(file, line+1).then((r) => {
+    if (r.msg === 'bpset') {
+      breakpoints.push(ink.breakpoints.add(file, line))
+    } else if (r.msg === 'bpremoved'){
+      let existing
+      if ((existing = ink.breakpoints.get(file, line, breakpoints)[0]) != null) {
+        breakpoints = breakpoints.filter(x => x !== existing)
+        existing.destroy()
+      }
+    }
+  })
+}
+
+export function clearall() {
+  breakpoints.forEach((bp) => bp.destroy())
+  clearbps()
+}
+
+export function getBPs() {
+  console.log(getbps())
 }
 
 export function togglebp(ed = atom.workspace.getActiveTextEditor()) {

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -1,4 +1,5 @@
 'use babel'
+/** @jsx etch.dom */
 
 import { CompositeDisposable } from 'atom'
 import { views } from '../ui'
@@ -11,7 +12,7 @@ let {nextline, stepin, finish, stepexpr, clearbps} =
 
 let {togglebp, getbps} = client.import({rpc: ['togglebp', 'getbps']})
 
-let ink, active, stepper, subs
+let ink, active, stepper, subs, BreakpointRegistry
 
 export function activate() {
   subs = new CompositeDisposable
@@ -64,12 +65,13 @@ let breakpoints = []
 function bp(file, line) {
   togglebp(file, line+1).then((r) => {
     if (r.msg === 'bpset') {
-      breakpoints.push(ink.breakpoints.add(file, line))
+      breakpoints.push(BreakpointRegistry.add(file, line))
     } else if (r.msg === 'bpremoved'){
-      let existing
-      if ((existing = ink.breakpoints.get(file, line, breakpoints)[0]) != null) {
-        breakpoints = breakpoints.filter(x => x !== existing)
-        existing.destroy()
+      let i
+      if ((i = breakpoints.findIndex(bp => bp.file === file && bp.line === line)) > -1) {
+        let bp = breakpoints[i]
+        breakpoints.splice(i, 1)
+        bp.destroy()
       }
     }
   })
@@ -99,5 +101,5 @@ export function consumeInk(i) {
       {icon: 'sign-in', command: 'julia-debug:step-into-function'}
     ]
   })
-  subs.add(ink.breakpoints.addScope('source.julia'))
+  BreakpointRegistry = new ink.breakpoints('source.julia')
 }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -52,7 +52,9 @@ client.handle({
     stepper.goto(file, line - 1)
     stepper.setText(views.render(text))
     workspace.update()
-  }
+  },
+  working() { client.ipc.loading.working() },
+  doneWorking() { client.ipc.loading.done() }
 })
 
 export function finish()   { requireDebugging(() => client.import('finish')()) }
@@ -69,10 +71,11 @@ function bufferForFile(file) {
 }
 
 function bp(file, line) {
-  client.require(() => {
-    // loadgallium().then(() => {
-      breakpoints.toggle(file, line)
-    // })
+  client.require(async () => {
+    let bp = breakpoints.toggle(file, line)
+    await loadgallium()
+    let response = await ((bp ? addsourcebp : removesourcebp)(file, line))
+    console.log(response)
   })
 }
 

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -76,7 +76,6 @@ function startListening() {
         let buffer = ed.getBuffer()
         buffer.onDidChangeModified(m => {
           let file = buffer.getPath()
-          let bp
           // unsaved changes in buffer -> deactivate all breakpoints
           if (m === true) {
             forBPinFile(file, bp => {
@@ -115,8 +114,7 @@ function startListening() {
 }
 
 function forBPinFile(file, f) {
-  let bp
-  for (bp of breakpoints) {
+  for (let bp of breakpoints) {
     if (bp.file === file) {
       f(bp)
     }
@@ -124,8 +122,7 @@ function forBPinFile(file, f) {
 }
 
 function bufferForFile(file) {
-  let ed
-  for (ed of atom.workspace.getTextEditors()) {
+  for (let ed of atom.workspace.getTextEditors()) {
     if (ed.getBuffer().getPath() === file) {
       return ed.getBuffer()
     }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -77,7 +77,7 @@ function bp(file, line) {
       await loadgallium()
       let response = await ((bp ? addsourcebp : removesourcebp)(file, line+1))
     } catch (e) {
-      console.error('Setting breakpoint:', response)
+      console.error('Setting breakpoint:', e)
       breakpoints.toggle(file, line)
     }
   })

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -7,11 +7,8 @@ import { client } from '../connection'
 
 import workspace from './workspace'
 
-let {nextline, stepin, finish, stepexpr, clearbps} =
-  client.import(['nextline', 'stepin', 'finish', 'stepexpr', 'clearbps'])
-
-let {addsourcebp, removesourcebp, getbps, loadgallium} =
-  client.import({rpc: ['addsourcebp', 'removesourcebp', 'getbps', 'loadgallium']})
+let {addsourcebp, removesourcebp, getbps, loadgallium, clearbps} =
+  client.import(['addsourcebp', 'removesourcebp', 'getbps', 'loadgallium', 'clearbps'])
 
 let ink, active, stepper, subs, BreakpointManager
 
@@ -61,10 +58,10 @@ function stepto(file, line, text) {
   workspace.update()
 }
 
-export function nextline() { requireDebugging(() => nextline()) }
-export function stepin()   { requireDebugging(() => stepin()) }
-export function finish()   { requireDebugging(() => finish()) }
-export function stepexpr() { requireDebugging(() => stepexpr()) }
+export function finish()   { requireDebugging(() => client.import('finish')()) }
+export function nextline() { requireDebugging(() => client.import('nextline')()) }
+export function stepexpr() { requireDebugging(() => client.import('stepexpr')()) }
+export function stepin()   { requireDebugging(() => client.import('stepin')()) }
 
 let breakpoints = []
 

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -106,7 +106,7 @@ function bp(file, line) {
 export function clearall() {
   breakpoints.forEach((bp) => bp.destroy())
   breakpoints = []
-  clearbps()
+  if (client.isActive()) clearbps()
 }
 
 export function getBPs() {

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -78,46 +78,51 @@ function startListening() {
           // unsaved changes in buffer -> deactivate all breakpoints
           if (m === true) {
             // clear the breakpoints in gallium
-            for (bp of breakpoints) {
-              if (bp.file === file) {
-                togglebp(bp.file, bp.line+1).then(r => {
-                  if (r.msg !== 'bpremoved') {
-                    console.error('inconsistent status!')
-                  }
-                })
-                bp.updateLineToMarkerPosition()
-              }
-            }
+            forBPinFile(file, bp => {
+              togglebp(bp.file, bp.line+1).then(r => {
+                if (r.msg !== 'bpremoved') {
+                  console.error('julia-client: internal: tried to clear a ' +
+                                'non-existant breakpoint:')
+                  console.error(bp)
+                }
+              })
+              bp.updateLineToMarkerPosition()
+            })
             // and set them to inactive in atom
-            for (bp of breakpoints) {
-              if (bp.file === file) {
-                bp.origStatus = bp.status
-                bp.status = 'inactive'
-              }
-            }
+            forBPinFile(file, bp => {
+              bp.origStatus = bp.status
+              bp.status = 'inactive'
+            })
           } else {
             // reset status for all breakpoints
-            for (bp of breakpoints) {
-              if (bp.file === file) {
-                bp.status = bp.origStatus
-                bp.updateLineToMarkerPosition()
-              }
-            }
+            forBPinFile(file, bp => {
+              bp.status = bp.origStatus
+              bp.updateLineToMarkerPosition()
+            })
             // and set them in gallium
-            for (bp of breakpoints) {
-              if (bp.file === file) {
-                togglebp(bp.file, bp.line+1).then(r => {
-                  if (r.msg !== 'bpset') {
-                    console.error('inconsistent status!')
-                  }
-                })
-              }
-            }
+            forBPinFile(file, bp => {
+              togglebp(bp.file, bp.line+1).then(r => {
+                if (r.msg !== 'bpset') {
+                  console.error('julia-client: internal: tried to set an ' +
+                                'already existing breakpoint:')
+                  console.error(bp)
+                }
+              })
+            })
           }
         })
       }
     }))
   }))
+}
+
+function forBPinFile(file, f) {
+  let bp
+  for (bp of breakpoints) {
+    if (bp.file === file) {
+      f(bp)
+    }
+  }
 }
 
 function bufferForFile(file) {
@@ -143,7 +148,9 @@ function bp(file, line) {
     if (modified === false) {
       togglebp(file, line+1).then(r => {
         if (r.msg !== 'bpremoved') {
-          console.error('inconsistent status!')
+          console.error('julia-client: internal: tried to clear a ' +
+                        'non-existant breakpoint:')
+          console.error(bp)
         }
       })
     }
@@ -154,7 +161,9 @@ function bp(file, line) {
     if (modified === false) {
       togglebp(file, line+1).then(r => {
         if (r.msg !== 'bpset') {
-          console.error('inconsistent status!')
+          console.error('julia-client: internal: tried to set an ' +
+                        'already existing breakpoint:')
+          console.error(bp)
         }
       })
     }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -10,7 +10,7 @@ import workspace from './workspace'
 let {addsourcebp, removesourcebp, getbps, loadgallium, clearbps} =
   client.import(['addsourcebp', 'removesourcebp', 'getbps', 'loadgallium', 'clearbps'])
 
-let ink, active, stepper, subs, BreakpointManager
+let ink, active, stepper, subs, breakpoints
 
 export function activate() {
   subs = new CompositeDisposable()
@@ -26,7 +26,7 @@ export function activate() {
 }
 
 export function deactivate() {
-  BreakpointManager.destroy()
+  breakpoints.destroy()
   subs.dispose()
 }
 
@@ -61,8 +61,6 @@ export function nextline() { requireDebugging(() => client.import('nextline')())
 export function stepexpr() { requireDebugging(() => client.import('stepexpr')()) }
 export function stepin()   { requireDebugging(() => client.import('stepin')()) }
 
-let breakpoints = []
-
 function bufferForFile(file) {
   for (let ed of atom.workspace.getTextEditors()) {
     if (ed.getBuffer().getPath() === file)
@@ -73,7 +71,7 @@ function bufferForFile(file) {
 
 function bp(file, line) {
   loadgallium().then(() => {
-    let i = breakpoints.findIndex(bp => bp.file === file && bp.line === line)
+    let i = breakpoints.breakpoints.findIndex(bp => bp.file === file && bp.line === line)
 
     if (!bufferForFile(file))
       return
@@ -81,9 +79,7 @@ function bp(file, line) {
     let modified = bufferForFile(file).isModified()
 
     if (i > -1) {
-      let bp = breakpoints[i]
-      breakpoints.splice(i, 1)
-
+      let bp = breakpoints.breakpoints[i]
       if (modified === false) {
         removesourcebp(file, line + 1).then(r => {
           if (r.msg !== 'bpremoved')
@@ -96,7 +92,7 @@ function bp(file, line) {
         addsourcebp(file, line + 1).then(r => {
           if (r.msg !== 'bpset')
             console.error(r.msg)
-          breakpoints.push(BreakpointManager.add(file, line, 'active'))
+          breakpoints.add(file, line, 'active')
         })
       }
     }
@@ -104,8 +100,7 @@ function bp(file, line) {
 }
 
 export function clearall() {
-  breakpoints.forEach((bp) => bp.destroy())
-  breakpoints = []
+  breakpoints.breakpoints.forEach(bp => bp.destroy())
   if (client.isActive()) clearbps()
 }
 
@@ -128,5 +123,5 @@ export function consumeInk(i) {
       {icon: 'sign-in', command: 'julia-debug:step-into-function'}
     ]
   })
-  BreakpointManager = new ink.breakpoints('source.julia')
+  breakpoints = new ink.breakpoints('source.julia')
 }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -28,6 +28,7 @@ export function activate() {
 }
 
 export function deactivate() {
+  BreakpointRegistry.destroy()
   subs.dispose()
 }
 

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -23,6 +23,8 @@ export function activate() {
   })
 
   subs.add(client.onDetached(() => debugmode(false)))
+
+  startListening()
 }
 
 export function deactivate() {
@@ -61,20 +63,102 @@ export function finish()   { requireDebugging(() => finish()) }
 export function stepexpr() { requireDebugging(() => stepexpr()) }
 
 let breakpoints = []
+let odcm
+
+// logic for activating breakpoints for saved files and deactivating when
+// they are modified
+function startListening() {
+  subs.add(atom.workspace.observeTextEditors(ed => {
+    subs.add(ed.observeGrammar(g => {
+      if (g.scopeName === 'source.julia') {
+        let buffer = ed.getBuffer()
+        buffer.onDidChangeModified(m => {
+          let file = buffer.getPath()
+          let bp
+          // unsaved changes in buffer -> deactivate all breakpoints
+          if (m === true) {
+            // clear the breakpoints in gallium
+            for (bp of breakpoints) {
+              if (bp.file === file) {
+                togglebp(bp.file, bp.line+1).then(r => {
+                  if (r.msg !== 'bpremoved') {
+                    console.error('inconsistent status!')
+                  }
+                })
+                bp.updateLineToMarkerPosition()
+              }
+            }
+            // and set them to inactive in atom
+            for (bp of breakpoints) {
+              if (bp.file === file) {
+                bp.origStatus = bp.status
+                bp.status = 'inactive'
+              }
+            }
+          } else {
+            // reset status for all breakpoints
+            for (bp of breakpoints) {
+              if (bp.file === file) {
+                bp.status = bp.origStatus
+                bp.updateLineToMarkerPosition()
+              }
+            }
+            // and set them in gallium
+            for (bp of breakpoints) {
+              if (bp.file === file) {
+                togglebp(bp.file, bp.line+1).then(r => {
+                  if (r.msg !== 'bpset') {
+                    console.error('inconsistent status!')
+                  }
+                })
+              }
+            }
+          }
+        })
+      }
+    }))
+  }))
+}
+
+function bufferForFile(file) {
+  let ed
+  for (ed of atom.workspace.getTextEditors()) {
+    if (ed.getBuffer().getPath() === file) {
+      return ed.getBuffer()
+    }
+  }
+  return null
+}
 
 function bp(file, line) {
-  togglebp(file, line+1).then((r) => {
-    if (r.msg === 'bpset') {
-      breakpoints.push(BreakpointRegistry.add(file, line))
-    } else if (r.msg === 'bpremoved'){
-      let i
-      if ((i = breakpoints.findIndex(bp => bp.file === file && bp.line === line)) > -1) {
-        let bp = breakpoints[i]
-        breakpoints.splice(i, 1)
-        bp.destroy()
-      }
+  let i = breakpoints.findIndex(bp => bp.file === file && bp.line === line)
+  let modified = bufferForFile(file).isModified()
+
+  if (i > -1) {
+    console.log('destroying');
+    let bp = breakpoints[i]
+    breakpoints.splice(i, 1)
+    bp.destroy()
+
+    if (modified === false) {
+      togglebp(file, line+1).then(r => {
+        if (r.msg !== 'bpremoved') {
+          console.error('inconsistent status!')
+        }
+      })
     }
-  })
+  } else {
+    console.log('constructing');
+    breakpoints.push(BreakpointRegistry.add(file, line, modified ? 'inactive' : 'active'))
+
+    if (modified === false) {
+      togglebp(file, line+1).then(r => {
+        if (r.msg !== 'bpset') {
+          console.error('inconsistent status!')
+        }
+      })
+    }
+  }
 }
 
 export function clearall() {

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -55,7 +55,7 @@ function debugmode(a) {
 }
 
 function stepto(file, line, text) {
-  stepper.goto(file, line-1)
+  stepper.goto(file, line - 1)
   stepper.setText(views.render(text))
   workspace.update()
 }
@@ -66,7 +66,6 @@ export function finish()   { requireDebugging(() => finish()) }
 export function stepexpr() { requireDebugging(() => stepexpr()) }
 
 let breakpoints = []
-let odcm
 
 // logic for activating breakpoints for saved files and deactivating when
 // they are modified
@@ -170,6 +169,7 @@ function bp(file, line) {
 
 export function clearall() {
   breakpoints.forEach((bp) => bp.destroy())
+  breakpoints = []
   clearbps()
 }
 

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -70,33 +70,15 @@ function bufferForFile(file) {
 }
 
 function bp(file, line) {
-  loadgallium().then(() => {
+  // loadgallium().then(() => {
     let i = breakpoints.breakpoints.findIndex(bp => bp.file === file && bp.line === line)
-
-    if (!bufferForFile(file))
-      return
-
-    let modified = bufferForFile(file).isModified()
-
     if (i > -1) {
       let bp = breakpoints.breakpoints[i]
-      if (modified === false) {
-        removesourcebp(file, line + 1).then(r => {
-          if (r.msg !== 'bpremoved')
-            console.error(r.msg)
-          bp.destroy()
-        })
-      }
+      bp.destroy()
     } else {
-      if (modified === false) {
-        addsourcebp(file, line + 1).then(r => {
-          if (r.msg !== 'bpset')
-            console.error(r.msg)
-          breakpoints.add(file, line, 'active')
-        })
-      }
+      breakpoints.add(file, line, 'active')
     }
-  })
+  // })
 }
 
 export function clearall() {

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -78,36 +78,32 @@ function startListening() {
           let bp
           // unsaved changes in buffer -> deactivate all breakpoints
           if (m === true) {
-            // clear the breakpoints in gallium
             forBPinFile(file, bp => {
+              // clear the breakpoints in gallium
               togglebp(bp.file, bp.line+1).then(r => {
                 if (r.msg !== 'bpremoved') {
                   console.error('julia-client: internal: tried to clear a ' +
                                 'non-existant breakpoint:')
                   console.error(bp)
                 }
+                // and set them to inactive in atom
+                bp.updateLineToMarkerPosition()
+                bp.origStatus = bp.status
+                bp.status = 'inactive'
               })
-              bp.updateLineToMarkerPosition()
-            })
-            // and set them to inactive in atom
-            forBPinFile(file, bp => {
-              bp.origStatus = bp.status
-              bp.status = 'inactive'
             })
           } else {
-            // reset status for all breakpoints
             forBPinFile(file, bp => {
-              bp.status = bp.origStatus
               bp.updateLineToMarkerPosition()
-            })
-            // and set them in gallium
-            forBPinFile(file, bp => {
+              // set breakpoints in gallium
               togglebp(bp.file, bp.line+1).then(r => {
                 if (r.msg !== 'bpset') {
                   console.error('julia-client: internal: tried to set an ' +
                                 'already existing breakpoint:')
                   console.error(bp)
                 }
+                // reset status
+                if (bp.origStatus) bp.status = bp.origStatus
               })
             })
           }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -22,8 +22,6 @@ export function activate() {
 
   subs.add(client.onDetached(() => debugmode(false)))
 
-  startListening()
-
   client.onDetached(() => clearall())
 }
 
@@ -64,54 +62,6 @@ export function stepexpr() { requireDebugging(() => client.import('stepexpr')())
 export function stepin()   { requireDebugging(() => client.import('stepin')()) }
 
 let breakpoints = []
-
-// logic for activating breakpoints for saved files and deactivating when
-// they are modified
-function startListening() {
-  subs.add(atom.workspace.observeTextEditors(ed => {
-    subs.add(ed.observeGrammar(g => {
-      if (g.scopeName === 'source.julia') {
-        let buffer = ed.getBuffer()
-        buffer.onDidChangeModified(m => {
-          let file = buffer.getPath()
-          // unsaved changes in buffer -> deactivate all breakpoints
-          if (m === true) {
-            forBPinFile(file, bp => {
-              // clear the breakpoints in gallium
-              removesourcebp(bp.file, bp.line + 1).then(r => {
-                if (r.msg !== 'bpremoved')
-                  console.error(r.msg)
-                // and set them to inactive in atom
-                bp.updateLineToMarkerPosition()
-                bp.origStatus = bp.status
-                bp.status = 'inactive'
-              })
-            })
-          } else {
-            forBPinFile(file, bp => {
-              bp.updateLineToMarkerPosition()
-              // set breakpoints in gallium
-              addsourcebp(bp.file, bp.line + 1).then(r => {
-                if (r.msg !== 'bpset')
-                  console.error(r.msg)
-                // reset status
-                if (bp.origStatus)
-                  bp.status = bp.origStatus
-              })
-            })
-          }
-        })
-      }
-    }))
-  }))
-}
-
-function forBPinFile(file, f) {
-  for (let bp of breakpoints) {
-    if (bp.file === file)
-      f(bp)
-  }
-}
 
 function bufferForFile(file) {
   for (let ed of atom.workspace.getTextEditors()) {

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -38,14 +38,16 @@ function activeError() {
 
 function requireDebugging(f) { activeError() || f() }
 
+function debugmode(a) {
+  active = a
+  if (!active) {
+    stepper.destroy()
+    workspace.update()
+  }
+}
+
 client.handle({
-  debugmode(a) {
-    active = a
-    if (!active) {
-      stepper.destroy()
-      workspace.update()
-    }
-  },
+  debugmode,
   stepto(file, line, text) {
     stepper.goto(file, line - 1)
     stepper.setText(views.render(text))

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -15,11 +15,6 @@ let ink, active, stepper, subs, breakpoints
 export function activate() {
   subs = new CompositeDisposable()
 
-  client.handle({
-    debugmode: state => debugmode(state),
-    stepto: (file, line, text) => stepto(file, line, text)
-  })
-
   subs.add(client.onDetached(() => debugmode(false)))
 
   client.onDetached(() => clearall())
@@ -42,19 +37,20 @@ function activeError() {
 
 function requireDebugging(f) { activeError() || f() }
 
-function debugmode(a) {
-  active = a
-  if (!active) {
-    stepper.destroy()
+client.handle({
+  debugmode(a) {
+    active = a
+    if (!active) {
+      stepper.destroy()
+      workspace.update()
+    }
+  },
+  stepto(file, line, text) {
+    stepper.goto(file, line - 1)
+    stepper.setText(views.render(text))
     workspace.update()
   }
-}
-
-function stepto(file, line, text) {
-  stepper.goto(file, line - 1)
-  stepper.setText(views.render(text))
-  workspace.update()
-}
+})
 
 export function finish()   { requireDebugging(() => client.import('finish')()) }
 export function nextline() { requireDebugging(() => client.import('nextline')()) }
@@ -66,7 +62,7 @@ function bufferForFile(file) {
     if (ed.getBuffer().getPath() === file)
       return ed.getBuffer()
   }
-  return null
+  return
 }
 
 function bp(file, line) {

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -13,7 +13,7 @@ let {nextline, stepin, finish, stepexpr, clearbps} =
 let {addsourcebp, removesourcebp, getbps, loadgallium} =
   client.import({rpc: ['addsourcebp', 'removesourcebp', 'getbps', 'loadgallium']})
 
-let ink, active, stepper, subs, BreakpointRegistry
+let ink, active, stepper, subs, BreakpointManager
 
 export function activate() {
   subs = new CompositeDisposable()
@@ -31,7 +31,7 @@ export function activate() {
 }
 
 export function deactivate() {
-  BreakpointRegistry.destroy()
+  BreakpointManager.destroy()
   subs.dispose()
 }
 
@@ -149,7 +149,7 @@ function bp(file, line) {
         addsourcebp(file, line + 1).then(r => {
           if (r.msg !== 'bpset')
             console.error(r.msg)
-          breakpoints.push(BreakpointRegistry.add(file, line, 'active'))
+          breakpoints.push(BreakpointManager.add(file, line, 'active'))
         })
       }
     }
@@ -181,5 +181,5 @@ export function consumeInk(i) {
       {icon: 'sign-in', command: 'julia-debug:step-into-function'}
     ]
   })
-  BreakpointRegistry = new ink.breakpoints('source.julia')
+  BreakpointManager = new ink.breakpoints('source.julia')
 }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -7,17 +7,18 @@ import { client } from '../connection'
 
 import workspace from './workspace'
 
-let {addsourcebp, removesourcebp, getbps, loadgallium, clearbps} =
-  client.import(['addsourcebp', 'removesourcebp', 'getbps', 'loadgallium', 'clearbps'])
+let {addsourcebp, removesourcebp, getbps, loadgallium} =
+  client.import(['addsourcebp', 'removesourcebp', 'getbps', 'loadgallium'])
 
 let ink, active, stepper, subs, breakpoints
 
 export function activate() {
   subs = new CompositeDisposable()
 
-  subs.add(client.onDetached(() => debugmode(false)))
-
-  client.onDetached(() => clearall())
+  subs.add(client.onDetached(() => {
+    debugmode(false)
+    clearbps()
+  }))
 }
 
 export function deactivate() {
@@ -71,9 +72,9 @@ function bp(file, line) {
   // })
 }
 
-export function clearall() {
+export function clearbps() {
   breakpoints.clear()
-  if (client.isActive()) clearbps()
+  if (client.isActive()) client.import('clearbps')()
 }
 
 export function getBPs() {

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -73,9 +73,13 @@ function bufferForFile(file) {
 function bp(file, line) {
   client.require(async () => {
     let bp = breakpoints.toggle(file, line)
-    await loadgallium()
-    let response = await ((bp ? addsourcebp : removesourcebp)(file, line+1))
-    console.log(response)
+    try {
+      await loadgallium()
+      let response = await ((bp ? addsourcebp : removesourcebp)(file, line+1))
+    } catch (e) {
+      console.error('Setting breakpoint:', response)
+      breakpoints.toggle(file, line)
+    }
   })
 }
 

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -93,7 +93,10 @@ export function getBPs() {
 }
 
 export function togglebp(ed = atom.workspace.getActiveTextEditor()) {
-  if (!ed) return
+  if (!ed || !ed.getPath()) {
+    atom.notifications.addError('Need a saved file to add a breakpoint')
+    return
+  }
   ed.getCursors().map((cursor) =>
     bp(ed.getPath(), cursor.getBufferPosition().row))
 }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -10,7 +10,8 @@ import workspace from './workspace'
 let {nextline, stepin, finish, stepexpr, clearbps} =
   client.import(['nextline', 'stepin', 'finish', 'stepexpr', 'clearbps'])
 
-let {togglebp, getbps, loadgallium} = client.import({rpc: ['togglebp', 'getbps', 'loadgallium']})
+let {addsourcebp, removesourcebp, getbps, loadgallium} =
+  client.import({rpc: ['addsourcebp', 'removesourcebp', 'getbps', 'loadgallium']})
 
 let ink, active, stepper, subs, BreakpointRegistry
 
@@ -80,12 +81,9 @@ function startListening() {
           if (m === true) {
             forBPinFile(file, bp => {
               // clear the breakpoints in gallium
-              togglebp(bp.file, bp.line + 1).then(r => {
-                if (r.msg !== 'bpremoved') {
-                  console.error('julia-client: internal: tried to clear a ' +
-                                'non-existant breakpoint:')
-                  console.error(bp)
-                }
+              removesourcebp(bp.file, bp.line + 1).then(r => {
+                if (r.msg !== 'bpremoved')
+                  console.error(r.msg)
                 // and set them to inactive in atom
                 bp.updateLineToMarkerPosition()
                 bp.origStatus = bp.status
@@ -96,14 +94,12 @@ function startListening() {
             forBPinFile(file, bp => {
               bp.updateLineToMarkerPosition()
               // set breakpoints in gallium
-              togglebp(bp.file, bp.line + 1).then(r => {
-                if (r.msg !== 'bpset') {
-                  console.error('julia-client: internal: tried to set an ' +
-                                'already existing breakpoint:')
-                  console.error(bp)
-                }
+              addsourcebp(bp.file, bp.line + 1).then(r => {
+                if (r.msg !== 'bpset')
+                  console.error(r.msg)
                 // reset status
-                if (bp.origStatus) bp.status = bp.origStatus
+                if (bp.origStatus)
+                  bp.status = bp.origStatus
               })
             })
           }
@@ -115,17 +111,15 @@ function startListening() {
 
 function forBPinFile(file, f) {
   for (let bp of breakpoints) {
-    if (bp.file === file) {
+    if (bp.file === file)
       f(bp)
-    }
   }
 }
 
 function bufferForFile(file) {
   for (let ed of atom.workspace.getTextEditors()) {
-    if (ed.getBuffer().getPath() === file) {
+    if (ed.getBuffer().getPath() === file)
       return ed.getBuffer()
-    }
   }
   return null
 }
@@ -133,6 +127,10 @@ function bufferForFile(file) {
 function bp(file, line) {
   loadgallium().then(() => {
     let i = breakpoints.findIndex(bp => bp.file === file && bp.line === line)
+
+    if (!bufferForFile(file))
+      return
+
     let modified = bufferForFile(file).isModified()
 
     if (i > -1) {
@@ -140,24 +138,18 @@ function bp(file, line) {
       breakpoints.splice(i, 1)
 
       if (modified === false) {
-        togglebp(file, line + 1).then(r => {
-          if (r.msg !== 'bpremoved') {
-            console.error('julia-client: internal: tried to clear a ' +
-                          'non-existant breakpoint:')
-            console.error(bp)
-          }
+        removesourcebp(file, line + 1).then(r => {
+          if (r.msg !== 'bpremoved')
+            console.error(r.msg)
           bp.destroy()
         })
       }
     } else {
       if (modified === false) {
-        togglebp(file, line + 1).then(r => {
-          if (r.msg !== 'bpset') {
-            console.error('julia-client: internal: tried to set an ' +
-                          'already existing breakpoint:')
-            console.error(bp)
-          }
-          breakpoints.push(BreakpointRegistry.add(file, line, modified ? 'inactive' : 'active'))
+        addsourcebp(file, line + 1).then(r => {
+          if (r.msg !== 'bpset')
+            console.error(r.msg)
+          breakpoints.push(BreakpointRegistry.add(file, line, 'active'))
         })
       }
     }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -69,9 +69,11 @@ function bufferForFile(file) {
 }
 
 function bp(file, line) {
-  // loadgallium().then(() => {
-    breakpoints.toggle(file, line)
-  // })
+  client.require(() => {
+    // loadgallium().then(() => {
+      breakpoints.toggle(file, line)
+    // })
+  })
 }
 
 export function clearbps() {

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -10,12 +10,12 @@ import workspace from './workspace'
 let {nextline, stepin, finish, stepexpr, clearbps} =
   client.import(['nextline', 'stepin', 'finish', 'stepexpr', 'clearbps'])
 
-let {togglebp, getbps} = client.import({rpc: ['togglebp', 'getbps']})
+let {togglebp, getbps, loadgallium} = client.import({rpc: ['togglebp', 'getbps', 'loadgallium']})
 
 let ink, active, stepper, subs, BreakpointRegistry
 
 export function activate() {
-  subs = new CompositeDisposable
+  subs = new CompositeDisposable()
 
   client.handle({
     debugmode: state => debugmode(state),
@@ -25,6 +25,8 @@ export function activate() {
   subs.add(client.onDetached(() => debugmode(false)))
 
   startListening()
+
+  client.onDetached(() => clearall())
 }
 
 export function deactivate() {
@@ -34,7 +36,7 @@ export function deactivate() {
 
 function activeError() {
   if (!active) {
-    atom.notifications.addError("You need to be debugging to do that.", {
+    atom.notifications.addError('You need to be debugging to do that.', {
       detail: 'You can start debugging by setting a breakpoint,\nor by calling `@step f(args...)`.',
       dismissable: true
     })
@@ -80,7 +82,7 @@ function startListening() {
           if (m === true) {
             forBPinFile(file, bp => {
               // clear the breakpoints in gallium
-              togglebp(bp.file, bp.line+1).then(r => {
+              togglebp(bp.file, bp.line + 1).then(r => {
                 if (r.msg !== 'bpremoved') {
                   console.error('julia-client: internal: tried to clear a ' +
                                 'non-existant breakpoint:')
@@ -96,7 +98,7 @@ function startListening() {
             forBPinFile(file, bp => {
               bp.updateLineToMarkerPosition()
               // set breakpoints in gallium
-              togglebp(bp.file, bp.line+1).then(r => {
+              togglebp(bp.file, bp.line + 1).then(r => {
                 if (r.msg !== 'bpset') {
                   console.error('julia-client: internal: tried to set an ' +
                                 'already existing breakpoint:')
@@ -133,38 +135,37 @@ function bufferForFile(file) {
 }
 
 function bp(file, line) {
-  let i = breakpoints.findIndex(bp => bp.file === file && bp.line === line)
-  let modified = bufferForFile(file).isModified()
+  loadgallium().then(() => {
+    let i = breakpoints.findIndex(bp => bp.file === file && bp.line === line)
+    let modified = bufferForFile(file).isModified()
 
-  if (i > -1) {
-    console.log('destroying');
-    let bp = breakpoints[i]
-    breakpoints.splice(i, 1)
-    bp.destroy()
+    if (i > -1) {
+      let bp = breakpoints[i]
+      breakpoints.splice(i, 1)
 
-    if (modified === false) {
-      togglebp(file, line+1).then(r => {
-        if (r.msg !== 'bpremoved') {
-          console.error('julia-client: internal: tried to clear a ' +
-                        'non-existant breakpoint:')
-          console.error(bp)
-        }
-      })
+      if (modified === false) {
+        togglebp(file, line + 1).then(r => {
+          if (r.msg !== 'bpremoved') {
+            console.error('julia-client: internal: tried to clear a ' +
+                          'non-existant breakpoint:')
+            console.error(bp)
+          }
+          bp.destroy()
+        })
+      }
+    } else {
+      if (modified === false) {
+        togglebp(file, line + 1).then(r => {
+          if (r.msg !== 'bpset') {
+            console.error('julia-client: internal: tried to set an ' +
+                          'already existing breakpoint:')
+            console.error(bp)
+          }
+          breakpoints.push(BreakpointRegistry.add(file, line, modified ? 'inactive' : 'active'))
+        })
+      }
     }
-  } else {
-    console.log('constructing');
-    breakpoints.push(BreakpointRegistry.add(file, line, modified ? 'inactive' : 'active'))
-
-    if (modified === false) {
-      togglebp(file, line+1).then(r => {
-        if (r.msg !== 'bpset') {
-          console.error('julia-client: internal: tried to set an ' +
-                        'already existing breakpoint:')
-          console.error(bp)
-        }
-      })
-    }
-  }
+  })
 }
 
 export function clearall() {

--- a/lib/ui/views.coffee
+++ b/lib/ui/views.coffee
@@ -30,7 +30,10 @@ module.exports = views =
 
   lazy: ({head, id}, opts) ->
     conn = client.conn
-    opts.registerLazy id
+    if opts.registerLazy?
+      opts.registerLazy id
+    else
+      console.warn 'Unregistered lazy view'
     view = @ink.tree.treeView @render(head, opts), [],
       onToggle: once =>
         return unless client.conn == conn

--- a/styles/julia-client.less
+++ b/styles/julia-client.less
@@ -22,7 +22,7 @@
 }
 
 atom-text-editor.editor {
-  .keyword.control.end.julia {
+  .syntax--keyword.syntax--end {
     opacity: 0.5;
   }
 }


### PR DESCRIPTION
While this implementation basically works, there's still a lot to figure out:

- [x] ~~julia-client shouldn't need to maintain a stack of set breakpoints; it'd probably be best to only have that in julia so there's less potential for both sets of breakpoints to diverge~~
- [x] Breakpoints should probably be unset when their marker changes (i.e. line inserted above the breakpoint or soemthing like that). Maybe re-set them at the new location afterwards?
- [x] Only saved files should have their breakpoints actually applied, because that is the state Gallium sees. Maybe we should save files automatically when setting a breakpoint or something like that (which would require separate stacks, now that I think about it...)?
- [ ] Conditional breakpoints.
- [ ] Breakpoint pane.
- [ ] Other stuff I didn't yet think about, but this will be kinda tricky to get right I think.

Just for reference (need to get those if you want to try this branch):
- https://github.com/JunoLab/Atom.jl/tree/sp/breakpoints
- https://github.com/JunoLab/atom-ink/tree/sp/breakpoints