### PR TITLE
Adds option to display results as blocks

### DIFF
--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -51,6 +51,14 @@ config =
     description: "Limits the Console history's size."
     default: 10000
     order: 8
+  resultsDisplayMode:
+    type: 'string'
+    default: 'inline'
+    enum: [
+      {value:'inline', description:'Float results next to code'}
+      {value:'block', description:'Display results under code'}
+    ]
+    order: 10
 
 if process.platform != 'darwin'
   config.terminal =

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -23,12 +23,12 @@ module.exports =
         [[start], [end]] = range
         @ink.highlight editor, start, end
         r = null
-        setTimeout (=> r ?= new @ink.Result editor, [start, end]), 0.1
+        setTimeout (=> r ?= new @ink.Result editor, [start, end], type: atom.config.get 'julia-client.resultsDisplayMode'), 0.1
         evaluate({text, line: line+1, mod, path: edpath})
           .then (result) =>
             error = result.type == 'error'
             view = if error then result.view else result
-            if not r? or r.isDestroyed then r = new @ink.Result editor, [start, end]
+            if not r? or r.isDestroyed then r = new @ink.Result editor, [start, end], type: atom.config.get 'julia-client.resultsDisplayMode'
             registerLazy = (id) ->
               r.onDidDestroy client.withCurrent -> clearLazy [id]
               editor.onDidDestroy client.withCurrent -> clearLazy id


### PR DESCRIPTION
Adds option in the settings menu to change whether results are displayed inline (current behavior) or underneath using the `type` option in `ink.Results`. See https://github.com/JunoLab/atom-ink/pull/93