### PR TITLE
Layout logic

### DIFF
--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -34,6 +34,9 @@ module.exports = JuliaClient =
   consumeInk: (ink) ->
     commands.ink = ink
     x.consumeInk ink for x in [@connection, @runtime, @ui]
+    if atom.config.get('julia-client.useStandardLayout') and atom.workspace.getPanes().length == 1
+      # HACK: give atom time to open, or buffers go screwy
+      setTimeout (=> @ui.layout.standard()), 100
 
   consumeStatusBar: (bar) ->
     @runtime.consumeStatusBar bar

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -92,6 +92,7 @@ module.exports =
       'julia:open-startup-file': -> atom.workspace.open juno.misc.paths.home '.juliarc.jl'
       'julia:open-julia-home': -> shell.openItem juno.misc.paths.juliaHome()
       'julia:open-package-in-new-window': -> juno.misc.paths.openPackage()
+      'julia:standard-layout': -> juno.ui.layout.standard()
 
       'julia-client:work-in-file-folder': ->
         requireClient 'change working folder', ->

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -49,7 +49,7 @@ config =
   useStandardLayout:
     type: 'boolean'
     default: false
-    description: 'Open the console, workspace and plot pane when on start.'
+    description: 'Open the console, workspace and plot pane on start.'
     order: 7.5
   maximumConsoleSize:
     type: 'integer'

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -46,6 +46,11 @@ config =
     default: false
     description: 'Show Julia icons in the tool bar (requires restart).'
     order: 7
+  useStandardLayout:
+    type: 'boolean'
+    default: false
+    description: 'Open the console, workspace and plot pane when on start.'
+    order: 7.5
   maximumConsoleSize:
     type: 'integer'
     description: "Limits the Console history's size."

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -5,7 +5,7 @@ module.exports =
   selector:      require './ui/selector'
   views:         require './ui/views'
   progress:      require './ui/progress'
-
+  layout:        require './ui/layout'
 
   activate: (@client) ->
     @subs = new CompositeDisposable

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -1,0 +1,43 @@
+'use babel'
+
+function resetLayout() {
+  pane = atom.workspace.getPanes()[0]
+  for (let p of atom.workspace.getPanes().slice(1)) {
+    for (let item of p.getItems()) {
+      p.moveItemToPane(item, pane)
+    }
+  }
+}
+
+function createLayout(layout,
+                    pane = atom.workspace.getActivePane(),
+                    vertical = true) {
+  if (!layout) {
+  } else if (layout instanceof Array) {
+    let ps = [pane]
+    for (let l of layout.slice(1)) {
+      ps.push(vertical ? pane.splitDown() : pane.splitRight())
+    }
+    for (let i = 0; i < ps.length; i++) {
+      createLayout(layout[i], ps[i], !vertical)
+    }
+  } else if (layout.layout) {
+    layout.scale && pane.setFlexScale(layout.scale)
+    createLayout(layout.layout, pane, vertical)
+  } else {
+    pane.activateItem(layout)
+  }
+}
+
+function workspace() { return require('../runtime').workspace.ws }
+function cons() { return require('../runtime').console.c }
+function plots() { return require('../runtime').plots.pane }
+
+export function standard() {
+  for (let pane of [workspace(), cons(), plots()]) pane.close()
+  resetLayout()
+  createLayout([
+    [null, {layout: workspace(), scale: 0.5}],
+    {layout: [cons(), plots()], scale: 0.5}
+  ])
+}


### PR DESCRIPTION
The idea of this is to have commands which put Juno into an ide-esque layout without a lot of manually moving things around. There's also an option to do this by default on startup – we could enable this by default in uber-juno, but I haven't for now as I'm concerned it'll be too annoying for many users.