### PR TITLE
Update Juno forum address to 'discourse.julialang.org'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,13 @@ tires, but be ready to get your hands dirty!
 
 This project is composed of many sub-projects, and it can be hard to know the appropriate
 place to file issues. For that reason we prefer that non-developers report issues on the
-[Juno discussion forum](http://discuss.junolab.org/) under the "issue" category, and we can
+[Julia discussion forum](https://discourse.julialang.org) under the "usage" category with "juno" tag, and we can 
 funnel things through to the right places from there.
 
 ## Contributing
 
 If you have feature ideas you'd like to implement, or bugs you'd like to fix, feel free to
-open a [discussion](http://discuss.junolab.org/) under the "dev" category – we're always happy
+open a [discussion](https://discourse.julialang.org) under the "usage" category with "juno" tag – we're always happy 
 to help people flesh out their ideas or get unstuck on problems.
 
 If you look over the GitHub issues for the various packages, you may notice some labelled

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,13 @@ tires, but be ready to get your hands dirty!
 
 This project is composed of many sub-projects, and it can be hard to know the appropriate
 place to file issues. For that reason we prefer that non-developers report issues on the
-[Julia discussion forum](https://discourse.julialang.org) under the "usage" category with "juno" tag, and we can
+[Juno discussion forum](http://discuss.junolab.org/) under the "issue" category, and we can
 funnel things through to the right places from there.
 
 ## Contributing
 
 If you have feature ideas you'd like to implement, or bugs you'd like to fix, feel free to
-open a [discussion](https://discourse.julialang.org) under the "usage" category with "juno" tag – we're always happy
+open a [discussion](http://discuss.junolab.org/) under the "dev" category – we're always happy
 to help people flesh out their ideas or get unstuck on problems.
 
 If you look over the GitHub issues for the various packages, you may notice some labelled

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,13 @@ tires, but be ready to get your hands dirty!
 
 This project is composed of many sub-projects, and it can be hard to know the appropriate
 place to file issues. For that reason we prefer that non-developers report issues on the
-[Juno discussion forum](http://discuss.junolab.org/) under the "issue" category, and we can
+[Julia discussion forum](https://discourse.julialang.org) under the "usage" category with "juno" tag, and we can
 funnel things through to the right places from there.
 
 ## Contributing
 
 If you have feature ideas you'd like to implement, or bugs you'd like to fix, feel free to
-open a [discussion](http://discuss.junolab.org/) under the "dev" category – we're always happy
+open a [discussion](https://discourse.julialang.org) under the "usage" category with "juno" tag – we're always happy
 to help people flesh out their ideas or get unstuck on problems.
 
 If you look over the GitHub issues for the various packages, you may notice some labelled

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ funnel things through to the right places from there.
 ## Contributing
 
 If you have feature ideas you'd like to implement, or bugs you'd like to fix, feel free to
-open a [discussion](https://discourse.julialang.org) under the "usage" category with "juno" tag – we're always happy 
+open a [discussion](https://discourse.julialang.org) under the "development" category with "juno" tag – we're always happy 
 to help people flesh out their ideas or get unstuck on problems.
 
 If you look over the GitHub issues for the various packages, you may notice some labelled

--- a/lib/connection/messages.coffee
+++ b/lib/connection/messages.coffee
@@ -22,7 +22,7 @@ module.exports =
         Go to the Packages → Julia → Open Terminal menu and
         run `Pkg.update()`in Julia, then try again.
         If you still see an issue, please report it to:
-            http://discuss.junolab.org/
+            https://discourse.julialang.org/
         """
         dismissable: true
 


### PR DESCRIPTION
Shuld Juno always use "usage" category in Juila forum? or Juno can use "Development" category as well.