### PR TITLE
Add 'julia-client:run-all-chunks' for Weave code chunks

### DIFF
--- a/lib/misc.coffee
+++ b/lib/misc.coffee
@@ -6,6 +6,7 @@ module.exports =
   blocks:  require './misc/blocks'
   cells:   require './misc/cells'
   words:   require './misc/words'
+  weave:   require './misc/weave'
 
   bufferLines: (t, f) ->
     if not f? then [t, f] = [null, t]

--- a/lib/misc/weave.js
+++ b/lib/misc/weave.js
@@ -1,0 +1,24 @@
+'use babel'
+
+import 'atom';
+
+export function getCode(){
+  ed = atom.workspace.getActiveTextEditor();
+  text = ed.getText();
+  lines = text.split("\n");
+  N = ed.getLineCount();
+  var code = "";
+
+  for (i=0; i<N; i++)
+  {
+     scopes = ed.scopeDescriptorForBufferPosition([i,0]).scopes;
+     if (scopes.length > 1)
+     {
+         if (scopes[1] == "source.julia")
+         {
+             code += lines[i] + "\n";
+         }
+     }
+  }
+  return(code);
+}

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -28,6 +28,11 @@ module.exports =
         @withInk ->
           boot()
           juno.runtime.evaluation.evalAll()
+      'julia-client:run-all-chunks': (event) =>
+          cancelComplete event
+          @withInk ->
+          boot()
+          juno.runtime.evaluation.evalAllChunks()
       'julia-client:run-cell': =>
         @withInk ->
           boot()

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -3,9 +3,8 @@ path = require 'path'
 
 {client} =  require '../connection'
 {notifications, views, selector} = require '../ui'
-{paths, blocks, cells, words} = require '../misc'
+{paths, blocks, cells, words, weave} = require '../misc'
 modules = require './modules'
-
 {eval: evaluate, evalall, cd, clearLazy} = client.import rpc: ['eval', 'evalall'], msg: ['cd', 'clearLazy']
 
 module.exports =
@@ -55,6 +54,18 @@ module.exports =
             }).then (result) ->
         notifications.show "Evaluation Finished"
         require('../runtime').workspace.update()
+
+  evalAllChunks: ->
+    editor = atom.workspace.getActiveTextEditor()
+    atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
+    evalall({
+              path: editor.getPath()
+              module: editor.juliaModule
+              code: weave.getCode();
+            }).then (result) ->
+        notifications.show "Evaluation Finished"
+        require('../runtime').workspace.update()
+
 
   gotoSymbol: ->
     @withCurrentContext ({editor, mod}) =>


### PR DESCRIPTION
Adds command `julia-client:run-all-chunks` to evaluate all code from Weave `jmd` files as suggested in #311. I will add the keybinding in `language-weave` when this gets merged. 

I'm not sure if this is the best implementation, but it was simple to implement and works similarly to `run-file`.