### PR TITLE
Layout fix for 1.17

### DIFF
--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -34,7 +34,7 @@ module.exports = JuliaClient =
   consumeInk: (ink) ->
     commands.ink = ink
     x.consumeInk ink for x in [@connection, @runtime, @ui]
-    if atom.config.get('julia-client.useStandardLayout') and atom.workspace.getPanes().length == 1
+    if atom.config.get('julia-client.useStandardLayout') and not @ui.layout.isCustomLayout()
       # HACK: give atom time to open, or buffers go screwy
       setTimeout (=> @ui.layout.standard()), 100
 

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -13,8 +13,8 @@ export function isCustomLayout() {
 }
 
 function resetLayout() {
-  pane = atom.workspace.getPanes()[0]
-  for (let p of atom.workspace.getPanes().slice(1)) {
+  pane = getPanes()[0]
+  for (let p of getPanes().slice(1)) {
     for (let item of p.getItems()) {
       p.moveItemToPane(item, pane)
     }

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -1,5 +1,17 @@
 'use babel'
 
+function getPanes() {
+  if (atom.workspace.getBottomDock) {
+    return atom.workspace.getPanes().slice(0, -3)
+  } else {
+    return atom.workspace.getPanes()
+  }
+}
+
+export function isCustomLayout() {
+  return getPanes().length > 1
+}
+
 function resetLayout() {
   pane = atom.workspace.getPanes()[0]
   for (let p of atom.workspace.getPanes().slice(1)) {


### PR DESCRIPTION
Currently the "use standard layout" option never activates. This fixes that by ignoring the three docks.

Eventually we'll want to use docks for our layout anyway, but this gives us a short term fix.