### PR TITLE
Set number of threads to number of cores

### DIFF
--- a/lib/connection/process/basic.coffee
+++ b/lib/connection/process/basic.coffee
@@ -101,9 +101,12 @@ module.exports =
               socket: @clientSocket proc
 
   get_: (a...) ->
-    confnt = parseInt(atom.config.get('julia-client.juliaOptions.numberOfThreads'))
-    if confnt != 0 and isFinite(confnt)
-      process.env.JULIA_NUM_THREADS = confnt
+    confnt = atom.config.get('julia-client.juliaOptions.numberOfThreads')
+    confntInt = parseInt(confnt)
+    if confnt == 'auto'
+      process.env.JULIA_NUM_THREADS = require('physical-cpu-count')
+    else if confntInt != 0 and isFinite(confntInt)
+      process.env.JULIA_NUM_THREADS = confntInt
 
     if process.platform is 'win32'
       @getWindows a...

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -33,9 +33,9 @@ config =
         items:
           type: 'string'
       numberOfThreads:
-        title: 'Number of Threads (experimental, 0 will use global setting)'
+        title: 'Number of Threads (`global` will use global setting, `auto` sets it to number of cores)'
         type: 'string'
-        default: '0'
+        default: 'auto'
     order: 3
   notifications:
     type: 'boolean'

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "underscore-plus": "*",
     "atom-package-deps": "*",
     "coffee-script": "*",
+    "physical-cpu-count": "*",
     "etch": "*"
   },
   "consumedServices": {


### PR DESCRIPTION
by default. Have to use `physical-cpu-count` instead of `require('os').cpus().length` to account for hyperthreading.

cc @chrisrackauckas