### PR TITLE
unify copy and interrupt keybindings

### DIFF
--- a/keymaps/julia-client.cson
+++ b/keymaps/julia-client.cson
@@ -65,8 +65,8 @@
 
 '.platform-win32 .julia-terminal, .platform-linux .julia-terminal':
   'ctrl-j ctrl-m': 'julia-client:set-working-module'
-  'ctrl-c': 'ink-terminal:copy'
-  'ctrl-shift-c': 'julia-client:interrupt-julia'
+  'ctrl-c': 'julia-client:copy-or-interrupt'
+  'ctrl-shift-c': 'julia-client:copy-or-interrupt'
   'ctrl-v': 'ink-terminal:paste'
 
 '.platform-win32 atom-workspace,
@@ -93,4 +93,3 @@
   'f10': 'julia-debug:step-to-next-expression'
   'f11': 'julia-debug:step-into-function'
   'shift-f11': 'julia-debug:finish-function'
-  

--- a/keymaps/julia-client.cson
+++ b/keymaps/julia-client.cson
@@ -65,6 +65,9 @@
 
 '.platform-win32 .julia-terminal, .platform-linux .julia-terminal':
   'ctrl-j ctrl-m': 'julia-client:set-working-module'
+  'ctrl-c': 'ink-terminal:copy'
+  'ctrl-shift-c': 'julia-client:interrupt-julia'
+  'ctrl-v': 'ink-terminal:paste'
 
 '.platform-win32 atom-workspace,
  .platform-linux atom-workspace':
@@ -90,3 +93,4 @@
   'f10': 'julia-debug:step-to-next-expression'
   'f11': 'julia-debug:step-into-function'
   'shift-f11': 'julia-debug:finish-function'
+  

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -109,8 +109,11 @@ module.exports =
   stdin: (data) -> @clientCall 'STDIN', 'stdin', data
 
   interrupt: ->
-    if @isActive() and @isWorking()
-      @clientCall 'interrupts', 'interrupt'
+    if @isActive()
+      if @isWorking()
+        @clientCall 'interrupts', 'interrupt'
+      else if atom.config.get('julia-client.juliaOptions.consoleStyle') is 'REPL-based'
+        @clientCall 'interrupts', 'interruptREPL'
 
   kill: ->
     if @isActive()

--- a/lib/connection/process/basic2.js
+++ b/lib/connection/process/basic2.js
@@ -35,6 +35,8 @@ export function get_ (path, args) {
   }
 }
 
+// TODO: reduce code duplication in getUnix and getWindows
+
 function getUnix (path, args, env) {
   return new Promise((resolve, reject) => {
     tcp.listen().then((port, server) => {
@@ -56,6 +58,8 @@ function getUnix (path, args, env) {
             ty: ty,
             kill: () => ty.kill(),
             interrupt: () => ty.kill('SIGINT'),
+            // more robust REPL-only interrupt, in theory only needed on windows
+            // without powershell wrapper:
             interruptREPL: () => ty.write('\x03'),
             socket: sock,
             onExit: (f) => ty.on('exit', f),
@@ -101,6 +105,8 @@ function getWindows (path, args, env) {
                 ty.kill()
               },
               interrupt: () => sendSignalToWrapper('SIGINT', wrapPort),
+              // more robust REPL-only interrupt, in theory only needed on windows
+              // without powershell wrapper:
               interruptREPL: () => ty.write('\x03'),
               socket: sock,
               onExit: (f) => ty.on('exit', f),

--- a/lib/connection/process/basic2.js
+++ b/lib/connection/process/basic2.js
@@ -56,6 +56,7 @@ function getUnix (path, args, env) {
             ty: ty,
             kill: () => ty.kill(),
             interrupt: () => ty.kill('SIGINT'),
+            interruptREPL: () => ty.write('\x03'),
             socket: sock,
             onExit: (f) => ty.on('exit', f),
             onStderr: (f) => {},
@@ -100,6 +101,7 @@ function getWindows (path, args, env) {
                 ty.kill()
               },
               interrupt: () => sendSignalToWrapper('SIGINT', wrapPort),
+              interruptREPL: () => ty.write('\x03'),
               socket: sock,
               onExit: (f) => ty.on('exit', f),
               onStderr: (f) => {},

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -55,8 +55,9 @@ export function activate (ink) {
     }
     if (process.platform != 'darwin') {
       terminal.attachCustomKeyEventHandler((e) => {
-        // don't pass Ctrl-(Shift)-C/V to terminal
-        if (e.ctrlKey && (e.keyCode == 67 || e.keyCode == 86)) {
+        // don't pass Ctrl-(Shift)-C/V/J/K to terminal so Atom can handle
+        // interrupts/copying/pasting/julia-mode commands
+        if (e.ctrlKey && (e.keyCode == 67 || e.keyCode == 86 || e.keyCode == 74 || e.keyCode == 75)) {
           return false
         }
         return e

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -53,7 +53,21 @@ export function activate (ink) {
         cb(isvalid)
       })
     }
-
+    if (process.platform != 'darwin') {
+      terminal.attachCustomKeyEventHandler((e) => {
+        if (e.ctrlKey && e.keyCode == 67) { // c
+          if (e.shiftKey) {
+            return false
+          } else {
+            terminal.copySelection()
+          }
+          return false
+        } else if (e.ctrlKey && e.keyCode == 86) { // v
+          return false
+        }
+        return e
+      })
+    }
     // doesn't handle multiline URIs properly due to upstream bug (xterm.js#24)
     terminal.terminal.registerLinkMatcher(uriRegex, linkHandler, {validationCallback: validator})
 

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -55,21 +55,16 @@ export function activate (ink) {
     }
     if (process.platform != 'darwin') {
       terminal.attachCustomKeyEventHandler((e) => {
-        if (e.ctrlKey && e.keyCode == 67) { // ctrl-c
-          if (e.shiftKey) { // ctrl-shift-c
-            return false
-          } else {
-            terminal.copySelection()
-          }
-          return false
-        } else if (e.ctrlKey && e.keyCode == 86) { // ctrl-v
+        // don't pass Ctrl-(Shift)-C/V to terminal
+        if (e.ctrlKey && (e.keyCode == 67 || e.keyCode == 86)) {
           return false
         }
         return e
       })
     } else {
       terminal.attachCustomKeyEventHandler((e) => {
-        if (e.ctrlKey && e.keyCode == 67) { // ctrl-c
+        // don't pass ctrl-c to terminal
+        if (e.ctrlKey && e.keyCode == 67) {
           return false
         }
         return e

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -55,19 +55,26 @@ export function activate (ink) {
     }
     if (process.platform != 'darwin') {
       terminal.attachCustomKeyEventHandler((e) => {
-        if (e.ctrlKey && e.keyCode == 67) { // c
-          if (e.shiftKey) {
+        if (e.ctrlKey && e.keyCode == 67) { // ctrl-c
+          if (e.shiftKey) { // ctrl-shift-c
             return false
           } else {
             terminal.copySelection()
           }
           return false
-        } else if (e.ctrlKey && e.keyCode == 86) { // v
+        } else if (e.ctrlKey && e.keyCode == 86) { // ctrl-v
           return false
         }
         return e
       })
-    }
+    } else if (
+      terminal.attachCustomKeyEventHandler((e) => {
+        if (e.ctrlKey && e.keyCode == 67) { // ctrl-c
+          return false
+        }
+        return e
+      })
+    )
     // doesn't handle multiline URIs properly due to upstream bug (xterm.js#24)
     terminal.terminal.registerLinkMatcher(uriRegex, linkHandler, {validationCallback: validator})
 

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -67,14 +67,14 @@ export function activate (ink) {
         }
         return e
       })
-    } else if (
+    } else {
       terminal.attachCustomKeyEventHandler((e) => {
         if (e.ctrlKey && e.keyCode == 67) { // ctrl-c
           return false
         }
         return e
       })
-    )
+    }
     // doesn't handle multiline URIs properly due to upstream bug (xterm.js#24)
     terminal.terminal.registerLinkMatcher(uriRegex, linkHandler, {validationCallback: validator})
 

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -93,6 +93,12 @@ export function activate (ink) {
     terminal.clear()
   }))
 
+  subs.add(atom.commands.add('.julia-terminal', 'julia-client:copy-or-interrupt', () => {
+    if (!terminal.copySelection()) {
+      atom.commands.dispatch(terminal.view, 'julia-client:interrupt-julia')
+    }
+  }))
+
   subs.add(atom.commands.add('atom-workspace', 'julia-client:new-terminal', () => {
     let term = ink.InkTerminal.fromId(`terminal-julia-${Math.floor(Math.random()*10000000)}`)
     shellPty().then((pty) => term.attach(pty, true))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,642 @@
+{
+  "name": "julia-client",
+  "version": "0.6.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "atom-package-deps": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/atom-package-deps/-/atom-package-deps-4.6.0.tgz",
+      "integrity": "sha1-u4PwqXZWO0i+TquJ58hjHD7shI0=",
+      "requires": {
+        "atom-package-path": "1.1.0",
+        "sb-exec": "3.1.0",
+        "sb-fs": "3.0.0",
+        "semver": "5.4.1"
+      }
+    },
+    "atom-package-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/atom-package-path/-/atom-package-path-1.1.0.tgz",
+      "integrity": "sha1-tR/tvADnyM5SI9DYA9t6P09pYU8=",
+      "requires": {
+        "sb-callsite": "1.1.2"
+      }
+    },
+    "atom-space-pen-views": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/atom-space-pen-views/-/atom-space-pen-views-2.2.0.tgz",
+      "integrity": "sha1-plsskg7QL3JAFPp9Plw9ePv1mZc=",
+      "requires": {
+        "fuzzaldrin": "2.1.0",
+        "space-pen": "5.1.2"
+      }
+    },
+    "bl": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+      "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha1-wF2uDLeVkdBbMHCoQzqYyaiczFM="
+    },
+    "consistent-env": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/consistent-env/-/consistent-env-1.3.1.tgz",
+      "integrity": "sha1-9oI018afxt2WVviuI0Kc4EmbZfs=",
+      "requires": {
+        "lodash.uniq": "4.5.0"
+      }
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "d": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+      "requires": {
+        "es5-ext": "0.10.30"
+      }
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "emissary": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/emissary/-/emissary-1.3.3.tgz",
+      "integrity": "sha1-phjZLWgrIy0xER3DYlpd9mF5lgY=",
+      "requires": {
+        "es6-weak-map": "0.1.4",
+        "mixto": "1.0.0",
+        "property-accessors": "1.1.3",
+        "underscore-plus": "1.6.6"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.30",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
+      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      },
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "requires": {
+            "es5-ext": "0.10.30"
+          }
+        },
+        "es6-iterator": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+          "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.30",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "es6-symbol": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+          "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.30"
+          }
+        }
+      }
+    },
+    "es6-iterator": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+      "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
+      "requires": {
+        "d": "0.1.1",
+        "es5-ext": "0.10.30",
+        "es6-symbol": "2.0.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+      "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
+      "requires": {
+        "d": "0.1.1",
+        "es5-ext": "0.10.30"
+      }
+    },
+    "es6-weak-map": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+      "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+      "requires": {
+        "d": "0.1.1",
+        "es5-ext": "0.10.30",
+        "es6-iterator": "0.1.3",
+        "es6-symbol": "2.0.1"
+      }
+    },
+    "etch": {
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/etch/-/etch-0.12.6.tgz",
+      "integrity": "sha1-V9luAGbu4W4GNVgU9GuIKcb9XAU="
+    },
+    "expand-template": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.0.tgz",
+      "integrity": "sha512-kkjwkMqj0h4w/sb32ERCDxCQkREMCAgS39DscDnSwDsbxnwwM1BTZySdC3Bn1lhY7vL08n9GoO/fVTynjDgRyQ=="
+    },
+    "fuzzaldrin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fuzzaldrin/-/fuzzaldrin-2.1.0.tgz",
+      "integrity": "sha1-kCBMPi/appQbso0WZF1BgGOpDps="
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.2"
+      }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+    },
+    "grim": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/grim/-/grim-1.5.0.tgz",
+      "integrity": "sha1-sysI71Z88YUvgXWe2caLDXE5ajI=",
+      "requires": {
+        "emissary": "1.3.3"
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jquery": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
+      "integrity": "sha1-IoveaYoMYUMdwmMKahVPFYkNIxc="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mixto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mixto/-/mixto-1.0.0.tgz",
+      "integrity": "sha1-wyDvYbUvKJj1IuF9i7xtUG2EJbY="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "node-abi": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.1.2.tgz",
+      "integrity": "sha512-hmUtb8m75RSi7N+zZLYqe75XDvZB+6LyTBPkj2DConvNgQet2e3BIqEwe1LLvqMrfyjabuT5ZOrTioLCH1HTdA==",
+      "requires": {
+        "semver": "5.4.1"
+      }
+    },
+    "node-pty-prebuilt": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/node-pty-prebuilt/-/node-pty-prebuilt-0.7.3.tgz",
+      "integrity": "sha1-IHp68YA92hdsbavlTIB9N3uLF1k=",
+      "requires": {
+        "nan": "2.8.0",
+        "prebuild-install": "2.4.1"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+          "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+        }
+      }
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "requires": {
+        "are-we-there-yet": "1.1.4",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "physical-cpu-count": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz",
+      "integrity": "sha1-GN4vl+S/epVRrXURlCtUlverpmA="
+    },
+    "prebuild-install": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.4.1.tgz",
+      "integrity": "sha512-99TyEFYTTkBWANT+mwSptmLb9ZCLQ6qKIUE36fXSIOtShB0JNprL2hzBD8F1yIuT9btjFrFEwbRHXhqDi1HmRA==",
+      "requires": {
+        "expand-template": "1.1.0",
+        "github-from-package": "0.0.0",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "node-abi": "2.1.2",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "1.0.3",
+        "rc": "1.2.4",
+        "simple-get": "1.4.3",
+        "tar-fs": "1.16.0",
+        "tunnel-agent": "0.6.0",
+        "xtend": "4.0.1"
+      }
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "property-accessors": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/property-accessors/-/property-accessors-1.1.3.tgz",
+      "integrity": "sha1-Hd6EAkYxhlkJ7zBwM2VoDF+SixU=",
+      "requires": {
+        "es6-weak-map": "0.1.4",
+        "mixto": "1.0.0"
+      }
+    },
+    "pump": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
+      "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sb-callsite": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sb-callsite/-/sb-callsite-1.1.2.tgz",
+      "integrity": "sha1-KBkftm1k46PukghKlakPy1ECJDs="
+    },
+    "sb-exec": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/sb-exec/-/sb-exec-3.1.0.tgz",
+      "integrity": "sha1-NMxlCIoRZ1Lrcg/d7/ZtLC6V7FE=",
+      "requires": {
+        "consistent-env": "1.3.1",
+        "lodash.uniq": "4.5.0",
+        "sb-npm-path": "2.0.0"
+      }
+    },
+    "sb-fs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sb-fs/-/sb-fs-3.0.0.tgz",
+      "integrity": "sha1-+9zdMBDoChuOJ0kM7zNgZJdCA7g=",
+      "requires": {
+        "sb-promisify": "2.0.2",
+        "strip-bom-buf": "1.0.0"
+      }
+    },
+    "sb-memoize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/sb-memoize/-/sb-memoize-1.0.2.tgz",
+      "integrity": "sha1-EoN1xi3bnMT/qQXQxaWXwZuurY4="
+    },
+    "sb-npm-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sb-npm-path/-/sb-npm-path-2.0.0.tgz",
+      "integrity": "sha1-D2zCzzcd68p9k27Xa31MPMHrPVg=",
+      "requires": {
+        "sb-memoize": "1.0.2",
+        "sb-promisify": "2.0.2"
+      }
+    },
+    "sb-promisify": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/sb-promisify/-/sb-promisify-2.0.2.tgz",
+      "integrity": "sha1-QnelR1RIiqlnXYhuNU24lMm9yYE="
+    },
+    "semver": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-get": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-1.4.3.tgz",
+      "integrity": "sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=",
+      "requires": {
+        "once": "1.4.0",
+        "unzip-response": "1.0.2",
+        "xtend": "4.0.1"
+      }
+    },
+    "space-pen": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/space-pen/-/space-pen-5.1.2.tgz",
+      "integrity": "sha1-Ivu+EOCwROe3pHsCPamdlLWE748=",
+      "requires": {
+        "grim": "1.5.0",
+        "jquery": "2.1.4",
+        "underscore-plus": "1.6.6"
+      }
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom-buf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+      "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "tar-fs": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
+      "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+      "requires": {
+        "chownr": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.5.5"
+      }
+    },
+    "tar-stream": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+      "requires": {
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.1",
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "underscore": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+    },
+    "underscore-plus": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/underscore-plus/-/underscore-plus-1.6.6.tgz",
+      "integrity": "sha1-ZezeG9xEGjXYnmUP1w3PE65Dmn0=",
+      "requires": {
+        "underscore": "1.6.0"
+      }
+    },
+    "unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+    }
+  }
+}


### PR DESCRIPTION
fixes #403.

This has the added benefit that you can use one keybinding everywhere and it will do the smart thing and interrupt either in-editor or in the repl, depending on which is currently running something.

@MikeInnes: I'm not sure if this works for macs, so would be great if you could check.