### PR TITLE
only load .junorc.jl after connection established

### DIFF
--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -42,6 +42,7 @@ module.exports =
 
     @onAttached =>
       args = atom.config.get 'julia-client.juliaOptions.arguments'
+      @import('connected')()
       if args.length > 0
         @import('args') args
 

--- a/script/boot_repl.jl
+++ b/script/boot_repl.jl
@@ -26,7 +26,7 @@ try
   import Atom
   using Juno
   Atom.connect(port, welcome = precompile || install)
-  Atom.handle("connected") do args...
+  Atom.handle("connected") do
     ispath(junorc) && include(junorc)
     nothing
   end

--- a/script/boot_repl.jl
+++ b/script/boot_repl.jl
@@ -26,7 +26,10 @@ try
   import Atom
   using Juno
   Atom.connect(port, welcome = precompile || install)
-  ispath(junorc) && include(junorc)
+  Atom.handle("connected") do args...
+    ispath(junorc) && include(junorc)
+    nothing
+  end
 catch
   print(STDERR, "juno-msg-load")
   rethrow()

--- a/script/boot_sync.jl
+++ b/script/boot_sync.jl
@@ -27,7 +27,10 @@ try
   using Juno
   @sync begin
     Atom.connect(port, welcome = precompile || install)
-    ispath(junorc) && include(junorc)
+    Atom.handle("connected") do
+      ispath(junorc) && include(junorc)
+      nothing
+    end
   end
 catch
   print(STDERR, "juno-msg-load")


### PR DESCRIPTION
This makes sure that `pwd()` is correct as well as that communication works.

Mainly motivated by the fact that I want to generate an OhMyREPL theme, but for that to work together with the process cycler we need to defer any Atom <-> Julia communication until there's a connection.

Putting 
```
using OhMyREPL, Crayons
using OhMyREPL: Passes.SyntaxHighlighter

function generateOMRtheme()
  cs = SyntaxHighlighter.ColorScheme()

  colors = Juno.syntaxcolors()

  SyntaxHighlighter.symbol!(cs, Crayon(foreground = colors["symbol"]))
  SyntaxHighlighter.comment!(cs, Crayon(foreground = colors["comment"]))
  SyntaxHighlighter.string!(cs, Crayon(foreground = colors["string"]))
  SyntaxHighlighter.call!(cs, Crayon(foreground = colors["funccall"]))
  SyntaxHighlighter.op!(cs, Crayon(foreground = colors["operator"]))
  SyntaxHighlighter.keyword!(cs, Crayon(foreground = colors["keyword"]))
  SyntaxHighlighter.text!(cs, Crayon(foreground = colors["variable"]))
  SyntaxHighlighter.macro!(cs, Crayon(foreground = colors["macro"]))
  SyntaxHighlighter.function_def!(cs, Crayon(foreground = colors["funcdef"]))
  SyntaxHighlighter.argdef!(cs, Crayon(foreground = colors["type"]))
  SyntaxHighlighter.number!(cs, Crayon(foreground = colors["number"]))

  SyntaxHighlighter.add!("Atom", cs)

  OhMyREPL.colorscheme!("Atom")

  return cs
end
```
into `.juliarc.jl` (to cut down load times) and 
```
generateOMRtheme()
```
into `.junorc.jl` (because `Juno.syntaxcolors()` requires the julia process to communicate with Atom) will give you a nice theme easily then.