### PR TITLE
Fixed Typo in Atom Command

### DIFF
--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -81,7 +81,7 @@ module.exports =
       'julia-client:kill-julia': -> juno.connection.client.kill()
       'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
       # 'julia-client:reset-julia-server': -> juno.connection.local.server.reset() # server mode not functional
-      'julia-client:connnect-external-process': -> disrequireClient -> juno.connection.messages.connectExternal()
+      'julia-client:connect-external-process': -> disrequireClient -> juno.connection.messages.connectExternal()
       'julia-client:connect-platformio-terminal': -> disrequireClient -> juno.connection.terminal.runPlatformIOTerm()
       'julia-client:connect-terminal': -> disrequireClient -> juno.connection.terminal.connectedRepl()
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()


### PR DESCRIPTION
`connnect` -> `connect`

Also getting practice at pull requests, I guess I could have just mentioned this on Slack >.>