### PR TITLE
Change link to installation instructions in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 [![Developer Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/JunoLab/Juno) [![Build Status](https://travis-ci.org/JunoLab/atom-julia-client.svg?branch=master)](https://travis-ci.org/JunoLab/atom-julia-client) [![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://JunoLab.github.io/JunoDocs.jl/latest)
 
-This is the main repo for [Juno](http://junolab.org), the Julia IDE. Please see [here](https://github.com/JunoLab/uber-juno/blob/master/setup.md) for installation instructions and report problems at [the discussion board](http://discourse.julialang.org/).
+This is the main repo for [Juno](http://junolab.org), the Julia IDE. Please see [here](http://docs.junolab.org/latest/man/installation.html) for installation instructions and report problems at [the discussion board](http://discourse.julialang.org/).


### PR DESCRIPTION
The maintained installation instructions seems to be at http://docs.junolab.org/latest/man/installation.html or https://github.com/JunoLab/JunoDocs.jl/blob/master/docs/src/man/installation.md, but not at https://github.com/JunoLab/uber-juno/blob/master/setup.md.