### PR TITLE
Optionally allow for static port in "Connect External Process"

### DIFF
--- a/lib/connection/process/tcp.coffee
+++ b/lib/connection/process/tcp.coffee
@@ -31,8 +31,13 @@ module.exports =
 
   listen: ->
     return Promise.resolve(@port) if @port?
+    externalPort = atom.config.get('julia-client.juliaOptions.externalProcessPort')
+    if externalPort == 'random'
+      port = 0
+    else
+      port = parseInt(externalPort)
     new Promise (resolve) =>
       @server = net.createServer (c) => @handle c
-      @server.listen 0, '127.0.0.1', =>
+      @server.listen port, '127.0.0.1', =>
         @port = @server.address().port
         resolve @port

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -55,7 +55,7 @@ config =
       externalProcessPort:
             title: 'Port of external Julia process'
             type: 'string'
-            description: 'Ure `random` to use a new port each time, or enter an integer to set the port statically.'
+            description: 'Use `random` to use a new port each time, or enter an integer to set the port statically.'
             default: 'random'
             order: 7
   uiOptions:

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -55,7 +55,7 @@ config =
       externalProcessPort:
             title: 'Port of external Julia process'
             type: 'string'
-            description: 'Use `random` to use a new port each time, or enter an integer to set the port statically.'
+            description: '`random` will use a new port each time, or enter an integer to set the port statically.'
             default: 'random'
             order: 7
   uiOptions:

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -52,6 +52,12 @@ config =
         items:
           type: 'string'
         order: 6
+      externalProcessPort:
+            title: 'Port of external Julia process'
+            type: 'string'
+            description: 'Ure `random` to use a new port each time, or enter an integer to set the port statically.'
+            default: 'random'
+            order: 7
   uiOptions:
     title: 'UI Options'
     type: 'object'


### PR DESCRIPTION
Per [this thread](https://discourse.julialang.org/t/connecting-juno-to-work-with-julia-installed-on-a-remote-server/7494/14), it would be nice to have the option to use a static port for use with persistent ssh connections. This pull request implements this feature.