### PR TITLE
Correct line number offset in error messages

### DIFF
--- a/lib/misc/cells.js
+++ b/lib/misc/cells.js
@@ -42,7 +42,7 @@ export function get (ed) {
   var res = {
     range: [[range[0].row, range[0].column], [range[1].row, range[1].column]],
     selection: ed.getSelections()[0],
-    line: range[1].row,
+    line: range[0].row,
     text: text
   }
   return [res]


### PR DESCRIPTION
On Linux & OSX (at least), the line number offsets in the returned stack track attributed the error to the wrong line. This is because for block-evaluations line = end, rather than line = start (which is what it was for single-line evals). Usine line=start+1 fixes this in all my tests so far. 

Steps to test and reproduce.

Open Atom with uber-juno installed.
Make sure the file has the Julia language selected. 
Enter the following example
~~~~
function myfun()
  x = 1+b
  return x
end
myfun()
~~~~
Run this as a cell with Alt-Enter.
Expected result: the line x=1+b is highlighted.
Produced result: no line is highlighted and the error is indicated on line 6.
Result with patch: the correct line is highlighted.