### PR TITLE
toolbar: save icon name updated to sync with fa's update

### DIFF
--- a/lib/package/toolbar.coffee
+++ b/lib/package/toolbar.coffee
@@ -15,7 +15,7 @@ module.exports =
       iconset: 'ion'
 
     @bar.addButton
-      icon: 'floppy-o'
+      icon: 'save'
       callback: 'core:save'
       tooltip: 'Save'
       iconset: 'fa'


### PR DESCRIPTION
It seems like font awesome has updated the name of "Floppy Icon" from `floppy-o` to `save`. And that caused the icon to disappear from the toolbar. Here is a fix for that. 