### PR TITLE
Changed 'Defintion' to 'Definition' and 'Run block' to 'Run Block'

### DIFF
--- a/menus/julia-client.cson
+++ b/menus/julia-client.cson
@@ -1,7 +1,7 @@
 'context-menu':
   'atom-text-editor[data-grammar="source julia"]': [
-    {label: 'Run block', command: 'julia-client:run-block'}
-    {label: 'Go to Defintion', command: 'julia-client:goto-symbol'}
+    {label: 'Run Block', command: 'julia-client:run-block'}
+    {label: 'Go to Definition', command: 'julia-client:goto-symbol'}
     {label: 'Show Documentation', command: 'julia-client:show-documentation'}
     # {label: 'Toggle breakpoint', command: 'julia-debug:toggle-breakpoint'}
     {type: 'separator'}


### PR DESCRIPTION
Fixed some typos in the julia-client.cson file. Issue here: https://github.com/JunoLab/Juno.jl/issues/189#issue-381835022