### PR TITLE
Native remote connection support

### DIFF
--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -24,6 +24,7 @@ module.exports =
 
   consumeInk: (ink) ->
     @IPC.consumeInk ink
+    @ink = ink
 
   consumeTerminal: (term) ->
     @terminal.consumeTerminal term
@@ -38,6 +39,8 @@ module.exports =
     if not @client.isActive() and not @booting
       @booting = true
       p = @local.start()
+      if @ink?
+        @ink.Opener.allowRemoteFiles(atom.config.get('julia-client.juliaOptions.bootMode') is 'Remote')
       p.then =>
         @booting = false
       p.catch =>

--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -28,6 +28,9 @@ module.exports =
   consumeTerminal: (term) ->
     @terminal.consumeTerminal term
 
+  consumeGetServerConfig: (getconf) ->
+    @local.consumeGetServerConfig(getconf)
+
   boot: ->
     if not @client.isActive() and not @booting
       @booting = true

--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -39,6 +39,7 @@ module.exports =
     if not @client.isActive() and not @booting
       @booting = true
       p = @local.start(provider)
+      @client.setBootMode(provider)
       if @ink?
         @ink.Opener.allowRemoteFiles(provider == 'Remote')
       p.then =>

--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -31,6 +31,9 @@ module.exports =
   consumeGetServerConfig: (getconf) ->
     @local.consumeGetServerConfig(getconf)
 
+  consumeGetServerName: (name) ->
+    @local.consumeGetServerName(name)
+
   boot: ->
     if not @client.isActive() and not @booting
       @booting = true

--- a/lib/connection.coffee
+++ b/lib/connection.coffee
@@ -35,15 +35,21 @@ module.exports =
   consumeGetServerName: (name) ->
     @local.consumeGetServerName(name)
 
-  boot: ->
+  _boot: (provider) ->
     if not @client.isActive() and not @booting
       @booting = true
-      p = @local.start()
+      p = @local.start(provider)
       if @ink?
-        @ink.Opener.allowRemoteFiles(atom.config.get('julia-client.juliaOptions.bootMode') is 'Remote')
+        @ink.Opener.allowRemoteFiles(provider == 'Remote')
       p.then =>
         @booting = false
       p.catch =>
         @booting = false
       time "Julia Boot", @client.import('ping')().then =>
         metrics()
+
+  bootRemote: ->
+    @_boot('Remote')
+
+  boot: ->
+    @_boot(atom.config.get('julia-client.juliaOptions.bootMode'))

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -66,7 +66,9 @@ module.exports =
       path = ed.getPath()
       ind = path.indexOf(@remoteConfig.host)
       if ind > -1
-        return path.slice(ind + @remoteConfig.host.length, path.length)
+        path = path.slice(ind + @remoteConfig.host.length, path.length)
+        path = path.replace(/\\/g, '/')
+        return path
       else
         return path
 

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -126,6 +126,10 @@ module.exports =
       else if atom.config.get('julia-client.consoleOptions.consoleStyle') is 'REPL-based'
         @clientCall 'interrupts', 'interruptREPL'
 
+  disconnect: ->
+    if @isActive()
+      @clientCall 'disconnecting', 'disconnect'
+
   kill: ->
     if @isActive()
       if not @isWorking()

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -28,6 +28,8 @@ module.exports =
 
     @emitter = new Emitter
 
+    @bootMode = atom.config.get('julia-client.juliaOptions.bootMode')
+
     @ipc.writeMsg = (msg) =>
       if @isActive() and @conn.ready?() isnt false
         @conn.message msg
@@ -58,9 +60,11 @@ module.exports =
     @onBoot (proc) =>
       @remoteConfig = proc.config
 
+  setBootMode: (@bootMode) ->
+
   editorPath: (ed) ->
     if not ed? then return ed
-    if atom.config.get('julia-client.juliaOptions.bootMode') is not 'Remote'
+    if @bootMode is not 'Remote'
       return ed.getPath()
     else
       path = ed.getPath()

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -55,6 +55,20 @@ module.exports =
     @onDetached =>
       plotpane?.dispose()
 
+    @onBoot (proc) =>
+      @remoteConfig = proc.config
+
+  editorPath: (ed) ->
+    if not ed? then return ed
+    if atom.config.get('julia-client.juliaOptions.bootMode') is not 'Remote'
+      return ed.getPath()
+    else
+      path = ed.getPath()
+      ind = path.indexOf(@remoteConfig.host)
+      if ind > -1
+        return path.slice(ind + @remoteConfig.host.length, path.length)
+      else
+        return path
 
   deactivate: ->
     @emitter.dispose()

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -64,9 +64,7 @@ module.exports =
 
   editorPath: (ed) ->
     if not ed? then return ed
-    if @bootMode is not 'Remote'
-      return ed.getPath()
-    else
+    if @bootMode is 'Remote' and @remoteConfig?
       path = ed.getPath()
       if not path? then return path
       ind = path.indexOf(@remoteConfig.host)
@@ -76,6 +74,8 @@ module.exports =
         return path
       else
         return path
+    else
+      return ed.getPath()
 
   deactivate: ->
     @emitter.dispose()

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -175,7 +175,7 @@ module.exports =
   connectedError: (action = 'do that') ->
     if @isActive()
       atom.notifications.addError "Can't #{action} with a Julia client running.",
-        detail: "Stop the current client with Packages → Julia → Stop Julia."
+        description: "Stop the current client with Packages → Julia → Stop Julia."
       true
     else
       false
@@ -183,7 +183,7 @@ module.exports =
   notConnectedError: (action = 'do that') ->
     if not @isActive()
       atom.notifications.addError "Can't #{action} without a Julia client running.",
-        detail: "Start Julia using Packages → Julia → Start Julia."
+        description: "Start Julia using Packages → Julia → Start Julia."
       true
     else
       false

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -64,6 +64,7 @@ module.exports =
       return ed.getPath()
     else
       path = ed.getPath()
+      if not path? then return path
       ind = path.indexOf(@remoteConfig.host)
       if ind > -1
         path = path.slice(ind + @remoteConfig.host.length, path.length)

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -27,7 +27,6 @@ module.exports =
       @bootMode = p
     else
       @bootMode = atom.config.get('julia-client.juliaOptions.bootMode')
-    client.setBootMode(@bootMode)  
     switch @bootMode
       when 'Cycler' then cycler
       when 'Remote' then ssh

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -84,8 +84,6 @@ module.exports =
 
   start: ->
     [path, args] = [paths.jlpath(), client.clargs()]
-    if atom.config.get('julia-client.juliaOptions.bootMode') is not 'Remote'
-      paths.projectDir().then (dir) -> cd dir
     check = paths.getVersion()
 
     check.catch (err) =>
@@ -102,6 +100,11 @@ module.exports =
       .catch (e) ->
         client.detach()
         console.error("Julia exited with #{e}.")
+      .then ->
+        if atom.config.get('julia-client.juliaOptions.bootMode') is 'Remote'
+          ssh.withRemoteConfig((conf) -> cd conf.remote).catch ->
+        else
+          paths.projectDir().then (dir) -> cd dir
     proc
 
   spawnJulia: (path, args) ->

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -16,12 +16,10 @@ basic2 = require './process/basic2'
 
 module.exports =
   consumeGetServerConfig: (getconf) ->
-    if atom.config.get('julia-client.juliaOptions.bootMode') is 'Remote'
-      @provider().consumeGetServerConfig(getconf)
+    ssh.consumeGetServerConfig(getconf)
 
   consumeGetServerName: (name) ->
-    if atom.config.get('julia-client.juliaOptions.bootMode') is 'Remote'
-      @provider().consumeGetServerName(name)
+    ssh.consumeGetServerName(name)
 
   provider: ->
     switch atom.config.get 'julia-client.juliaOptions.bootMode'

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -6,7 +6,9 @@ cd = client.import 'cd', false
 
 # legacy
 basic  = require './process/basic'
+
 cycler = require './process/cycler'
+ssh = require './process/remote'
 # server = require './process/server'
 
 # new console
@@ -18,6 +20,7 @@ module.exports =
   provider: ->
     switch atom.config.get 'julia-client.juliaOptions.bootMode'
       when 'Cycler' then cycler
+      when 'Remote' then ssh
       when 'Basic'
         switch atom.config.get 'julia-client.consoleOptions.consoleStyle'
           when 'REPL-based' then basic2
@@ -28,7 +31,7 @@ module.exports =
       process.env.JULIA_EDITOR = "\"#{process.execPath}\" -a"
     else
       process.env.JULIA_EDITOR = "atom -a"
-      
+
     paths.getVersion()
       .then =>
         @provider().start? paths.jlpath(), client.clargs()

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -19,6 +19,10 @@ module.exports =
     if atom.config.get('julia-client.juliaOptions.bootMode') is 'Remote'
       @provider().consumeGetServerConfig(getconf)
 
+  consumeGetServerName: (name) ->
+    if atom.config.get('julia-client.juliaOptions.bootMode') is 'Remote'
+      @provider().consumeGetServerName(name)
+
   provider: ->
     switch atom.config.get 'julia-client.juliaOptions.bootMode'
       when 'Cycler' then cycler

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -80,7 +80,8 @@ module.exports =
 
   start: ->
     [path, args] = [paths.jlpath(), client.clargs()]
-    paths.projectDir().then (dir) -> cd dir
+    if atom.config.get('julia-client.juliaOptions.bootMode') is not 'Remote'
+      paths.projectDir().then (dir) -> cd dir
     check = paths.getVersion()
 
     check.catch (err) =>

--- a/lib/connection/local.coffee
+++ b/lib/connection/local.coffee
@@ -15,7 +15,9 @@ ssh = require './process/remote'
 basic2 = require './process/basic2'
 
 module.exports =
-  # server: server
+  consumeGetServerConfig: (getconf) ->
+    if atom.config.get('julia-client.juliaOptions.bootMode') is 'Remote'
+      @provider().consumeGetServerConfig(getconf)
 
   provider: ->
     switch atom.config.get 'julia-client.juliaOptions.bootMode'

--- a/lib/connection/messages.coffee
+++ b/lib/connection/messages.coffee
@@ -92,4 +92,4 @@ module.exports =
       client.onceAttached ->
         if not msg.isDismissed()
           msg.dismiss()
-          atom.notifications.addSuccess "Julia is connected."
+        atom.notifications.addSuccess "Julia is connected."

--- a/lib/connection/process/basic2.js
+++ b/lib/connection/process/basic2.js
@@ -36,7 +36,7 @@ export function get_ (path, args) {
 
 function getUnix (path, args, env) {
   return new Promise((resolve, reject) => {
-    tcp.listen().then((port, server) => {
+    tcp.listen().then((port) => {
       paths.fullPath(path).then((path) => {
         paths.projectDir().then((cwd) => {
           // space before port needed for pty.js on windows:
@@ -76,7 +76,7 @@ function getWindows (path, args, env) {
     return getUnix(path, args, env)
   }
   return new Promise((resolve, reject) => {
-    tcp.listen().then((port, server) => {
+    tcp.listen().then((port) => {
       freePort().then((wrapPort) => {
         paths.fullPath("powershell").then((psPath) => {
           paths.projectDir().then((cwd) => {

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -139,11 +139,24 @@ export function get_ (path, args) {
               reject()
             }
           })
-          let exec = atom.config.get('julia-client.remoteOptions.remoteJulia')
-          exec = exec + ' --color=yes -i -e \''
-          exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
-          exec = exec + '\' ' + port
-          
+          let jlpath = atom.config.get('julia-client.remoteOptions.remoteJulia')
+          let exec = ''
+          if (atom.config.get('julia-client.remoteOptions.tmux')) {
+            exec = exec + 'TERM=xterm-256color tmux new -s juno_tmux_session '
+            exec = exec + jlpath
+            exec = exec + ' --color=yes -i -e \''
+            exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
+            exec = exec + '\' ' + port
+            exec = exec + ` || tmux send-keys -t juno_tmux_session.0 \'Juno.connect(${port})\' ENTER`
+            exec = exec + ' && tmux attach -t juno_tmux_session '
+          } else {
+            exec = exec + jlpath + ' --color=yes -i -e \''
+            exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
+            exec = exec + '\' ' + port
+          }
+
+          console.log(exec)
+
           conn.exec(exec, { pty: true }, (err, stream) => {
             if (err) console.error(`Error while executing command \n\`${exec}\`\n on remote server.`)
 

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -174,7 +174,7 @@ export function get_ (path, args) {
             exec = exec + ' ' + args.join(' ')  + ' -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
             exec = exec + '\' ' + port
-            exec = exec + ` || tmux send-keys -t ${sessionName}.0 ^A ^K \'Juno.connect(${port})\' ENTER`
+            exec = exec + ` || tmux send-keys -t ${sessionName}.{left} ^A ^K \'Juno.connect(${port})\' ENTER`
             exec = exec + ` && tmux attach -t ${sessionName} `
           } else {
             exec = exec + jlpath + ' ' + args.join(' ')  + ' -e \''

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -171,13 +171,13 @@ export function get_ (path, args) {
             let sessionName = atom.config.get('julia-client.remoteOptions.tmux')
             exec = exec + `TERM=xterm-256color tmux new -s ${sessionName} `
             exec = exec + jlpath
-            exec = exec + ' --color=yes -i -e \''
+            exec = exec + args.join(' ')  + ' -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
             exec = exec + '\' ' + port
             exec = exec + ` || tmux send-keys -t ${sessionName}.0 ^A ^K \'Juno.connect(${port})\' ENTER`
             exec = exec + ` && TERM=xterm-256color tmux attach -t ${sessionName} `
           } else {
-            exec = exec + jlpath + ' --color=yes -i -e \''
+            exec = exec + jlpath + args.join(' ')  + ' -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
             exec = exec + '\' ' + port
           }

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -57,6 +57,33 @@ export function withRemoteConfig (f) {
   })
 }
 
+const storageKey = 'juno_remote_server_exec_key'
+
+function setRemoteExec (server, command) {
+  let store = getRemoteStore()
+  store[server] = command
+  setRemoteStore(store)
+}
+
+function getRemoteExec (server) {
+  let store = getRemoteStore()
+  return store[server]
+}
+
+function setRemoteStore (store) {
+  localStorage[storageKey] = JSON.stringify(store)
+}
+
+function getRemoteStore () {
+  let store = localStorage[storageKey]
+  if (store == undefined) {
+    store = []
+  } else {
+    store = JSON.parse(store)
+  }
+  return store
+}
+
 function showRemoteError (reason) {
   if (reason == 'nopackage') {
     atom.notifications.addInfo('ftp-remote-edit not installed')
@@ -75,6 +102,10 @@ function showRemoteError (reason) {
         }
       ]
     })
+  } else {
+    atom.notifications.addError('Remote Connection Failed', {
+      details: `Unknown Error: \n\n ${reason}`
+    })
   }
 }
 
@@ -88,6 +119,10 @@ export function consumeGetServerName (name) {
 
 export function get_ (path, args) {
   return withRemoteConfig(conf => {
+    let execs = getRemoteExec(conf.name)
+    if (!execs) {
+      console.log("open a dialog and get config here")
+    }
     return new Promise((resolve, reject) => {
       tcp.listen().then((port) => {
         let conn = new ssh.Client()
@@ -108,17 +143,19 @@ export function get_ (path, args) {
             if (err) console.error(`Error while executing command \n\`${exec}\`\n on remote server.`)
 
             stream.on('close', () => {
+              console.log('stream closed')
               conn.end()
             })
 
             let sock = socket(stream)
+            console.log(stream)
 
             // forward resize handling
             stream.resize = (cols, rows) => stream.setWindow(rows, cols, 999, 999)
             let proc = {
               ty: stream,
               kill: () => stream.signal('KILL'),
-              interrupt: () => stream.signal('SIGINT'),
+              interrupt: () => stream.write('\x03'), // signal handling doesn't seem to work :/
               interruptREPL: () => stream.write('\x03'),
               socket: sock,
               onExit: (f) => stream.on('close', f),
@@ -129,20 +166,38 @@ export function get_ (path, args) {
           })
         }).on('tcp connection', (info, accept, reject) => {
           let stream = accept() // connect to forwarded connection
+          console.log(stream)
           stream.on('close', () => {
             console.log('accepted stream was closed')
+            conn.end()
+          })
+          stream.on('error', () => {
+            console.log('accepted stream errored')
+            conn.end()
+          })
+          stream.on('finish', () => {
+            console.log('accepted stream finished')
             conn.end()
           })
           // start server that the julia server can connect to
           let sock = net.createConnection({ port: port }, () => {
             stream.pipe(sock).pipe(stream)
           })
+          console.log(sock)
           sock.on('close', () => {
             console.log('local forwarder died')
             conn.end()
           })
+          sock.on('error', () => {
+            console.log('local forwarder errored')
+            conn.end()
+          })
+          sock.on('finish', () => {
+            console.log('local forwarder finished')
+            conn.end()
+          })
         }).connect(conf)
-
+        console.log(conn)
         conn.on('close', (err) => {
           console.log(`connection closed with ${err}`)
         })

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -37,7 +37,20 @@ export function withRemoteConfig (f) {
       if (reason == 'nopackage') {
         atom.notifications.addInfo('ftp-remote-edit not installed')
       } else if (reason == 'noservers') {
-        atom.notifications.addInfo('Please select a project')
+        let notif = atom.notifications.addInfo('Please select a project', {
+          description: `Connect to a server in the ftp-remote-edit tree view.`,
+          dismissable: true,
+          buttons: [
+            {
+              text: 'Togle Remote Tree View',
+              onDidClick: () => {
+                let edview = atom.views.getView(atom.workspace.getActiveTextEditor())
+                atom.commands.dispatch(edview, 'ftp-remote-edit:toggle')
+                notif.dismiss()
+              }
+            }
+          ]
+        })
       }
       reject()
     })

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -168,21 +168,21 @@ export function get_ (path, args) {
           let jlpath = atom.config.get('julia-client.remoteOptions.remoteJulia')
           let exec = ''
           if (atom.config.get('julia-client.remoteOptions.tmux')) {
-            let sessionName = atom.config.get('julia-client.remoteOptions.tmux')
-            exec = exec + `TERM=xterm-256color tmux new -s ${sessionName} `
+            let sessionName = atom.config.get('julia-client.remoteOptions.tmuxName')
+            exec = exec + `tmux new -s ${sessionName} `
             exec = exec + jlpath
             exec = exec + ' ' + args.join(' ')  + ' -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
             exec = exec + '\' ' + port
             exec = exec + ` || tmux send-keys -t ${sessionName}.0 ^A ^K \'Juno.connect(${port})\' ENTER`
-            exec = exec + ` && TERM=xterm-256color tmux attach -t ${sessionName} `
+            exec = exec + ` && tmux attach -t ${sessionName} `
           } else {
             exec = exec + jlpath + ' ' + args.join(' ')  + ' -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
             exec = exec + '\' ' + port
           }
 
-          conn.exec(exec, { pty: true }, (err, stream) => {
+          conn.exec(exec, { pty: { term: "xterm-256color" } }, (err, stream) => {
             if (err) console.error(`Error while executing command \n\`${exec}\`\n on remote server.`)
 
             stream.on('close', () => {

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -17,16 +17,18 @@ export function get (path, args) {
 }
 
 export function get_ (path, args) {
+  let settings = atom.config.get('julia-client.remoteOptions')
   return new Promise((resolve, reject) => {
     tcp.listen().then((port) => {
-      console.log("juno listening on port "+port)
       let conn = new ssh.Client()
 
       conn.on('ready', () => {
-        conn.forwardIn('127.0.0.1', 8888, err => {
+        conn.forwardIn('127.0.0.1', port, err => {
+          if (err) console.error(`Error while forwarding remote connection from ${port}`)
         })
-        conn.shell((err, stream) => {
-          if (err) console.error(err)
+        let exec = `${settings.remoteJulia} --color=yes -i -e "using Atom; using Juno; Juno.connect(${port})"`
+        conn.exec(exec, {pty: true}, (err, stream) => {
+          if (err) console.error(`Error while executing command \n\`${exec}\`\n on remote server.`)
 
           stream.on('close', () => {
             conn.end()
@@ -34,8 +36,8 @@ export function get_ (path, args) {
 
           let sock = socket(stream)
 
+          // forward resize handling
           stream.resize = (cols, rows) => stream.setWindow(rows, cols, 999, 999)
-
           let proc = {
             ty: stream,
             kill: () => stream.signal('KILL'),
@@ -46,21 +48,20 @@ export function get_ (path, args) {
             onStderr: (f) => stream.stderr.on('data', data => f(data.toString())),
             onStdout: (f) => stream.on('data', data => f(data.toString())),
           }
-          console.log(proc)
           resolve(proc)
         })
       }).on('tcp connection', (info, accept, reject) => {
         let stream = accept() // connect to forwarded connection
         // start server that the julia server can connect to
-        let sock = net.createConnection({port: port}, () => {
+        let sock = net.createConnection({ port: port }, () => {
           stream.pipe(sock).pipe(stream)
         })
       }).connect({
-        host: 'micha-eis.nerdpol.ovh',
-        port: 24,
-        username: 'basti',
-        privateKey: require('fs').readFileSync('/home/pfitzseb/.ssh/serverhome_openssh'),
-        passphrase: ""
+        host: settings.server,
+        port: settings.port,
+        username: settings.username,
+        privateKey: require('fs').readFileSync(settings.keyfile),
+        passphrase: settings.passphrase
       })
     })
   })

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -18,29 +18,30 @@ export function get (path, args) {
   })
 }
 
-export function getConnectionSettings () {
-  let settings = atom.config.get('julia-client.remoteOptions')
-
-  if (getRemoteConf) console.log(getRemoteConf())
-
-  let connectionSettings = {}
-  if (settings.usekeyfile) {
-    connectionSettings = {
-      host: settings.server,
-      port: settings.port,
-      username: settings.username,
-      privateKey: require('fs').readFileSync(settings.keyfile),
-      passphrase: settings.passphrase
+function getConnectionSettings () {
+  return new Promise((resolve, reject) => {
+    if (getRemoteConf) {
+      let conf = getRemoteConf('Juno requests access to your server configuration to open a terminal.')
+      conf.then(conf => resolve(conf)).catch(reason => reject(reason))
+    } else {
+      reject('nopackage')
     }
-  } else {
-    connectionSettings = {
-      host: settings.server,
-      port: settings.port,
-      username: settings.username,
-      password: settings.passphrase
-    }
-  }
-  return connectionSettings
+  })
+}
+
+export function withRemoteConfig (f) {
+  return new Promise((resolve, reject) => {
+    getConnectionSettings().then(conf => {
+      resolve(f(conf))
+    }).catch(reason => {
+      if (reason == 'nopackage') {
+        atom.notifications.addInfo('ftp-remote-edit not installed')
+      } else if (reason == 'noservers') {
+        atom.notifications.addInfo('Please select a project')
+      }
+      reject()
+    })
+  })
 }
 
 export function consumeGetServerConfig (getconf) {
@@ -48,47 +49,54 @@ export function consumeGetServerConfig (getconf) {
 }
 
 export function get_ (path, args) {
-  let connectionSettings = getConnectionSettings()
+  return withRemoteConfig(conf => {
+    return new Promise((resolve, reject) => {
+      tcp.listen().then((port) => {
+        let conn = new ssh.Client()
 
-  return new Promise((resolve, reject) => {
-    tcp.listen().then((port) => {
-      let conn = new ssh.Client()
-
-      conn.on('ready', () => {
-        conn.forwardIn('127.0.0.1', port, err => {
-          if (err) console.error(`Error while forwarding remote connection from ${port}`)
-        })
-        let exec = `${atom.config.get('julia-client.remoteOptions.remoteJulia')} --color=yes -i -e "using Atom; using Juno; Juno.connect(${port})"`
-        conn.exec(exec, {pty: true}, (err, stream) => {
-          if (err) console.error(`Error while executing command \n\`${exec}\`\n on remote server.`)
-
-          stream.on('close', () => {
-            conn.end()
+        conn.on('ready', () => {
+          conn.forwardIn('127.0.0.1', port, err => {
+            if (err) {
+              console.error(`Error while forwarding remote connection from ${port}: ${err}`)
+              atom.notifications.addError(`Port in use`, {
+                description: `Port ${port} on the remote server already in use.
+                              Try again with another port.`
+              })
+              reject()
+            }
           })
+          let exec = `${atom.config.get('julia-client.remoteOptions.remoteJulia')} --color=yes -i -e "using Atom; using Juno; Juno.connect(${port})"`
+          conn.exec(exec, {pty: true}, (err, stream) => {
+            if (err) console.error(`Error while executing command \n\`${exec}\`\n on remote server.`)
 
-          let sock = socket(stream)
+            stream.on('close', () => {
+              conn.end()
+            })
 
-          // forward resize handling
-          stream.resize = (cols, rows) => stream.setWindow(rows, cols, 999, 999)
-          let proc = {
-            ty: stream,
-            kill: () => stream.signal('KILL'),
-            interrupt: () => stream.signal('SIGINT'),
-            interruptREPL: () => stream.write('\x03'),
-            socket: sock,
-            onExit: (f) => stream.on('close', f),
-            onStderr: (f) => stream.stderr.on('data', data => f(data.toString())),
-            onStdout: (f) => stream.on('data', data => f(data.toString())),
-          }
-          resolve(proc)
-        })
-      }).on('tcp connection', (info, accept, reject) => {
-        let stream = accept() // connect to forwarded connection
-        // start server that the julia server can connect to
-        let sock = net.createConnection({ port: port }, () => {
-          stream.pipe(sock).pipe(stream)
-        })
-      }).connect(connectionSettings)
+            let sock = socket(stream)
+
+            // forward resize handling
+            stream.resize = (cols, rows) => stream.setWindow(rows, cols, 999, 999)
+            let proc = {
+              ty: stream,
+              kill: () => stream.signal('KILL'),
+              interrupt: () => stream.signal('SIGINT'),
+              interruptREPL: () => stream.write('\x03'),
+              socket: sock,
+              onExit: (f) => stream.on('close', f),
+              onStderr: (f) => stream.stderr.on('data', data => f(data.toString())),
+              onStdout: (f) => stream.on('data', data => f(data.toString())),
+            }
+            resolve(proc)
+          })
+        }).on('tcp connection', (info, accept, reject) => {
+          let stream = accept() // connect to forwarded connection
+          // start server that the julia server can connect to
+          let sock = net.createConnection({ port: port }, () => {
+            stream.pipe(sock).pipe(stream)
+          })
+        }).connect(conf)
+      })
     })
   })
 }

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -1,0 +1,71 @@
+'use babel'
+
+import tcp from './tcp'
+import * as pty from 'node-pty-prebuilt'
+import net from 'net'
+import { paths, mutex } from '../../misc'
+import * as ssh from 'ssh2'
+
+export var lock = mutex()
+
+export function get (path, args) {
+  return lock((release) => {
+    let p = get_(path, args)
+    release(p.then(({socket}) => socket))
+    return p
+  })
+}
+
+export function get_ (path, args) {
+  return new Promise((resolve, reject) => {
+    tcp.listen().then((port) => {
+      console.log("juno listening on port "+port)
+      let conn = new ssh.Client()
+
+      conn.on('ready', () => {
+        conn.forwardIn('127.0.0.1', 8888, err => {
+        })
+        conn.shell((err, stream) => {
+          if (err) console.error(err)
+
+          stream.on('close', () => {
+            conn.end()
+          })
+
+          let sock = socket(stream)
+
+          stream.resize = (cols, rows) => stream.setWindow(rows, cols, 999, 999)
+
+          let proc = {
+            ty: stream,
+            kill: () => stream.signal('KILL'),
+            interrupt: () => stream.signal('SIGINT'),
+            interruptREPL: () => stream.write('\x03'),
+            socket: sock,
+            onExit: (f) => stream.on('close', f),
+            onStderr: (f) => stream.stderr.on('data', data => f(data.toString())),
+            onStdout: (f) => stream.on('data', data => f(data.toString())),
+          }
+          console.log(proc)
+          resolve(proc)
+        })
+      }).on('tcp connection', (info, accept, reject) => {
+        let stream = accept() // connect to forwarded connection
+        // start server that the julia server can connect to
+        let sock = net.createConnection({port: port}, () => {
+          stream.pipe(sock).pipe(stream)
+        })
+      }).connect({
+        host: 'micha-eis.nerdpol.ovh',
+        port: 24,
+        username: 'basti',
+        privateKey: require('fs').readFileSync('/home/pfitzseb/.ssh/serverhome_openssh'),
+        passphrase: ""
+      })
+    })
+  })
+}
+
+function socket (ty) {
+  return tcp.next()
+}

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -171,13 +171,13 @@ export function get_ (path, args) {
             let sessionName = atom.config.get('julia-client.remoteOptions.tmux')
             exec = exec + `TERM=xterm-256color tmux new -s ${sessionName} `
             exec = exec + jlpath
-            exec = exec + args.join(' ')  + ' -e \''
+            exec = exec + ' ' + args.join(' ')  + ' -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
             exec = exec + '\' ' + port
             exec = exec + ` || tmux send-keys -t ${sessionName}.0 ^A ^K \'Juno.connect(${port})\' ENTER`
             exec = exec + ` && TERM=xterm-256color tmux attach -t ${sessionName} `
           } else {
-            exec = exec + jlpath + args.join(' ')  + ' -e \''
+            exec = exec + jlpath + ' ' + args.join(' ')  + ' -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
             exec = exec + '\' ' + port
           }

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -168,13 +168,14 @@ export function get_ (path, args) {
           let jlpath = atom.config.get('julia-client.remoteOptions.remoteJulia')
           let exec = ''
           if (atom.config.get('julia-client.remoteOptions.tmux')) {
-            exec = exec + 'TERM=xterm-256color tmux new -s juno_tmux_session '
+            let sessionName = atom.config.get('julia-client.remoteOptions.tmux')
+            exec = exec + `TERM=xterm-256color tmux new -s ${sessionName} `
             exec = exec + jlpath
             exec = exec + ' --color=yes -i -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
             exec = exec + '\' ' + port
-            exec = exec + ` || tmux send-keys -t juno_tmux_session.0 ^A ^K \'Juno.connect(${port})\' ENTER`
-            exec = exec + ' && TERM=xterm-256color tmux attach -t juno_tmux_session '
+            exec = exec + ` || tmux send-keys -t ${sessionName}.0 ^A ^K \'Juno.connect(${port})\' ENTER`
+            exec = exec + ` && TERM=xterm-256color tmux attach -t ${sessionName} `
           } else {
             exec = exec + jlpath + ' --color=yes -i -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -5,6 +5,7 @@ import * as pty from 'node-pty-prebuilt'
 import net from 'net'
 import { paths, mutex } from '../../misc'
 import * as ssh from 'ssh2'
+import fs from 'fs'
 
 export var lock = mutex()
 
@@ -138,17 +139,19 @@ export function get_ (path, args) {
               reject()
             }
           })
-          let exec = `${atom.config.get('julia-client.remoteOptions.remoteJulia')} --color=yes -i -e "using Atom; using Juno; Juno.connect(${port})"`
-          conn.exec(exec, {pty: true}, (err, stream) => {
+          let exec = atom.config.get('julia-client.remoteOptions.remoteJulia')
+          exec = exec + ' --color=yes -i -e \''
+          exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
+          exec = exec + '\' ' + port
+          
+          conn.exec(exec, { pty: true }, (err, stream) => {
             if (err) console.error(`Error while executing command \n\`${exec}\`\n on remote server.`)
 
             stream.on('close', () => {
-              console.log('stream closed')
               conn.end()
             })
 
             let sock = socket(stream)
-            console.log(stream)
 
             // forward resize handling
             stream.resize = (cols, rows) => stream.setWindow(rows, cols, 999, 999)
@@ -200,6 +203,7 @@ export function get_ (path, args) {
         console.log(conn)
         conn.on('close', (err) => {
           console.log(`connection closed with ${err}`)
+
         })
         conn.on('error', (err) => {
           console.log('connection errored:')
@@ -213,6 +217,13 @@ export function get_ (path, args) {
   })
 }
 
-function socket (ty) {
-  return tcp.next()
+function socket (stream) {
+  conn = tcp.next()
+  failure = new Promise((resolve, reject) => {
+    stream.on('close', (err) => {
+      conn.dispose()
+      reject(err)
+    })
+  })
+  return Promise.race([conn, failure])
 }

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -50,7 +50,7 @@ export function get_ (path, args) {
         conn.forwardIn('127.0.0.1', port, err => {
           if (err) console.error(`Error while forwarding remote connection from ${port}`)
         })
-        let exec = `${settings.remoteJulia} --color=yes -i -e "using Atom; using Juno; Juno.connect(${port})"`
+        let exec = `${atom.config.get('julia-client.remoteOptions.remoteJulia')} --color=yes -i -e "using Atom; using Juno; Juno.connect(${port})"`
         conn.exec(exec, {pty: true}, (err, stream) => {
           if (err) console.error(`Error while executing command \n\`${exec}\`\n on remote server.`)
 

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -12,6 +12,7 @@ export var lock = mutex()
 let getRemoteConf = undefined
 let getRemoteName = undefined
 let serversettings = {}
+let currentServer = undefined
 
 export function get (path, args) {
   return lock((release) => {
@@ -203,6 +204,7 @@ export function get_ (path, args) {
               onExit: (f) => stream.on('close', f),
               onStderr: (f) => stream.stderr.on('data', data => f(data.toString())),
               onStdout: (f) => stream.on('data', data => f(data.toString())),
+              config: conf
             }
             resolve(proc)
           })

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -147,8 +147,8 @@ export function get_ (path, args) {
             exec = exec + ' --color=yes -i -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
             exec = exec + '\' ' + port
-            exec = exec + ` || tmux send-keys -t juno_tmux_session.0 \'Juno.connect(${port})\' ENTER`
-            exec = exec + ' && tmux attach -t juno_tmux_session '
+            exec = exec + ` || tmux send-keys -t juno_tmux_session.0 ^A ^K \'Juno.connect(${port})\' ENTER`
+            exec = exec + ' && TERM=xterm-256color tmux attach -t juno_tmux_session '
           } else {
             exec = exec + jlpath + ' --color=yes -i -e \''
             exec = exec + fs.readFileSync(paths.script('boot_repl.jl'))
@@ -171,6 +171,7 @@ export function get_ (path, args) {
             let proc = {
               ty: stream,
               kill: () => stream.signal('KILL'),
+              disconnect: () => stream.close(),
               interrupt: () => stream.write('\x03'), // signal handling doesn't seem to work :/
               interruptREPL: () => stream.write('\x03'),
               socket: sock,

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -122,7 +122,7 @@ function showRemoteError (reason) {
         {
           text: 'Togle Remote Tree View',
           onDidClick: () => {
-            let edview = atom.views.getView(atom.workspace.getActiveTextEditor())
+            let edview = atom.views.getView(atom.workspace)
             atom.commands.dispatch(edview, 'ftp-remote-edit:toggle')
             notif.dismiss()
           }

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -39,12 +39,13 @@ export function withRemoteConfig (f) {
     } else {
       getRemoteName().then(name => {
         name = name.toString()
-        if (serversettings[name]) {
-          resolve(f(serversettings[name]))
+        let cachedSettings = serversettings[name]
+        if (cachedSettings) {
+          resolve(f(maybe_add_agent(cachedSettings)))
         } else {
           getConnectionSettings().then(conf => {
             serversettings[name] = conf
-            resolve(f(conf))
+            resolve(f(maybe_add_agent(conf)))
           }).catch(reason => {
             showRemoteError(reason)
             reject()
@@ -56,6 +57,30 @@ export function withRemoteConfig (f) {
       })
     }
   })
+}
+
+function maybe_add_agent (conf) {
+  if (conf && !conf.agent && atom.config.get('julia-client.remoteOptions.agentAuth')) {
+    let sshsock = ssh_socket()
+    if (sshsock) {
+      conf.agent = sshsock
+      conf.agentForward = atom.config.get('julia-client.remoteOptions.forwardAgent')
+    }
+  }
+  return conf
+}
+
+function ssh_socket () {
+  let sock = process.env['SSH_AUTH_SOCK']
+  if (sock) {
+    return sock
+  } else {
+    if (process.platform == 'win32') {
+      return 'pageant'
+    } else {
+      return ''
+    }
+  }
 }
 
 const storageKey = 'juno_remote_server_exec_key'

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -182,8 +182,6 @@ export function get_ (path, args) {
             exec = exec + '\' ' + port
           }
 
-          console.log(exec)
-
           conn.exec(exec, { pty: true }, (err, stream) => {
             if (err) console.error(`Error while executing command \n\`${exec}\`\n on remote server.`)
 
@@ -211,49 +209,29 @@ export function get_ (path, args) {
           })
         }).on('tcp connection', (info, accept, reject) => {
           let stream = accept() // connect to forwarded connection
-          console.log(stream)
           stream.on('close', () => {
-            console.log('accepted stream was closed')
             conn.end()
           })
           stream.on('error', () => {
-            console.log('accepted stream errored')
             conn.end()
           })
           stream.on('finish', () => {
-            console.log('accepted stream finished')
             conn.end()
           })
           // start server that the julia server can connect to
           let sock = net.createConnection({ port: port }, () => {
             stream.pipe(sock).pipe(stream)
           })
-          console.log(sock)
           sock.on('close', () => {
-            console.log('local forwarder died')
             conn.end()
           })
           sock.on('error', () => {
-            console.log('local forwarder errored')
             conn.end()
           })
           sock.on('finish', () => {
-            console.log('local forwarder finished')
             conn.end()
           })
         }).connect(conf)
-        console.log(conn)
-        conn.on('close', (err) => {
-          console.log(`connection closed with ${err}`)
-
-        })
-        conn.on('error', (err) => {
-          console.log('connection errored:')
-          console.log(err)
-        })
-        conn.on('end', () => {
-          console.log('connection ended')
-        })
       })
     })
   })

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -8,6 +8,8 @@ import * as ssh from 'ssh2'
 
 export var lock = mutex()
 
+let getRemoteConf = undefined
+
 export function get (path, args) {
   return lock((release) => {
     let p = get_(path, args)
@@ -18,6 +20,8 @@ export function get (path, args) {
 
 export function getConnectionSettings () {
   let settings = atom.config.get('julia-client.remoteOptions')
+
+  if (getRemoteConf) console.log(getRemoteConf())
 
   let connectionSettings = {}
   if (settings.usekeyfile) {
@@ -37,6 +41,10 @@ export function getConnectionSettings () {
     }
   }
   return connectionSettings
+}
+
+export function consumeGetServerConfig (getconf) {
+  getRemoteConf = getconf
 }
 
 export function get_ (path, args) {

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -16,8 +16,32 @@ export function get (path, args) {
   })
 }
 
-export function get_ (path, args) {
+export function getConnectionSettings () {
   let settings = atom.config.get('julia-client.remoteOptions')
+
+  let connectionSettings = {}
+  if (settings.usekeyfile) {
+    connectionSettings = {
+      host: settings.server,
+      port: settings.port,
+      username: settings.username,
+      privateKey: require('fs').readFileSync(settings.keyfile),
+      passphrase: settings.passphrase
+    }
+  } else {
+    connectionSettings = {
+      host: settings.server,
+      port: settings.port,
+      username: settings.username,
+      password: settings.passphrase
+    }
+  }
+  return connectionSettings
+}
+
+export function get_ (path, args) {
+  let connectionSettings = getConnectionSettings()
+
   return new Promise((resolve, reject) => {
     tcp.listen().then((port) => {
       let conn = new ssh.Client()
@@ -56,13 +80,7 @@ export function get_ (path, args) {
         let sock = net.createConnection({ port: port }, () => {
           stream.pipe(sock).pipe(stream)
         })
-      }).connect({
-        host: settings.server,
-        port: settings.port,
-        username: settings.username,
-        privateKey: require('fs').readFileSync(settings.keyfile),
-        passphrase: settings.passphrase
-      })
+      }).connect(connectionSettings)
     })
   })
 }

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -9,6 +9,8 @@ import * as ssh from 'ssh2'
 export var lock = mutex()
 
 let getRemoteConf = undefined
+let getRemoteName = undefined
+let serversettings = {}
 
 export function get (path, args) {
   return lock((release) => {
@@ -31,34 +33,57 @@ function getConnectionSettings () {
 
 export function withRemoteConfig (f) {
   return new Promise((resolve, reject) => {
-    getConnectionSettings().then(conf => {
-      resolve(f(conf))
-    }).catch(reason => {
-      if (reason == 'nopackage') {
-        atom.notifications.addInfo('ftp-remote-edit not installed')
-      } else if (reason == 'noservers') {
-        let notif = atom.notifications.addInfo('Please select a project', {
-          description: `Connect to a server in the ftp-remote-edit tree view.`,
-          dismissable: true,
-          buttons: [
-            {
-              text: 'Togle Remote Tree View',
-              onDidClick: () => {
-                let edview = atom.views.getView(atom.workspace.getActiveTextEditor())
-                atom.commands.dispatch(edview, 'ftp-remote-edit:toggle')
-                notif.dismiss()
-              }
-            }
-          ]
-        })
-      }
+    if (getRemoteName === undefined) {
       reject()
-    })
+    } else {
+      getRemoteName().then(name => {
+        name = name.toString()
+        if (serversettings[name]) {
+          resolve(f(serversettings[name]))
+        } else {
+          getConnectionSettings().then(conf => {
+            serversettings[name] = conf
+            resolve(f(conf))
+          }).catch(reason => {
+            showRemoteError(reason)
+            reject()
+          })
+        }
+      }).catch(reason => {
+        showRemoteError(reason)
+        reject()
+      })
+    }
   })
+}
+
+function showRemoteError (reason) {
+  if (reason == 'nopackage') {
+    atom.notifications.addInfo('ftp-remote-edit not installed')
+  } else if (reason == 'noservers') {
+    let notif = atom.notifications.addInfo('Please select a project', {
+      description: `Connect to a server in the ftp-remote-edit tree view.`,
+      dismissable: true,
+      buttons: [
+        {
+          text: 'Togle Remote Tree View',
+          onDidClick: () => {
+            let edview = atom.views.getView(atom.workspace.getActiveTextEditor())
+            atom.commands.dispatch(edview, 'ftp-remote-edit:toggle')
+            notif.dismiss()
+          }
+        }
+      ]
+    })
+  }
 }
 
 export function consumeGetServerConfig (getconf) {
   getRemoteConf = getconf
+}
+
+export function consumeGetServerName (name) {
+  getRemoteName = name
 }
 
 export function get_ (path, args) {

--- a/lib/connection/process/remote.js
+++ b/lib/connection/process/remote.js
@@ -129,11 +129,30 @@ export function get_ (path, args) {
           })
         }).on('tcp connection', (info, accept, reject) => {
           let stream = accept() // connect to forwarded connection
+          stream.on('close', () => {
+            console.log('accepted stream was closed')
+            conn.end()
+          })
           // start server that the julia server can connect to
           let sock = net.createConnection({ port: port }, () => {
             stream.pipe(sock).pipe(stream)
           })
+          sock.on('close', () => {
+            console.log('local forwarder died')
+            conn.end()
+          })
         }).connect(conf)
+
+        conn.on('close', (err) => {
+          console.log(`connection closed with ${err}`)
+        })
+        conn.on('error', (err) => {
+          console.log('connection errored:')
+          console.log(err)
+        })
+        conn.on('end', () => {
+          console.log('connection ended')
+        })
       })
     })
   })

--- a/lib/connection/process/tcp.coffee
+++ b/lib/connection/process/tcp.coffee
@@ -37,7 +37,7 @@ module.exports =
     else
       port = parseInt(externalPort)
     new Promise (resolve) =>
-      @server = net.createServer (c) => @handle c
+      @server = net.createServer((sock) => @handle(sock))
       @server.listen port, '127.0.0.1', =>
         @port = @server.address().port
-        resolve @port
+        resolve(@port)

--- a/lib/connection/process/tcp.coffee
+++ b/lib/connection/process/tcp.coffee
@@ -31,12 +31,12 @@ module.exports =
 
   listen: ->
     return Promise.resolve(@port) if @port?
-    externalPort = atom.config.get('julia-client.juliaOptions.externalProcessPort')
-    if externalPort == 'random'
-      port = 0
-    else
-      port = parseInt(externalPort)
     new Promise (resolve) =>
+      externalPort = atom.config.get('julia-client.juliaOptions.externalProcessPort')
+      if externalPort == 'random'
+        port = 0
+      else
+        port = parseInt(externalPort)
       @server = net.createServer((sock) => @handle(sock))
       @server.listen port, '127.0.0.1', =>
         @port = @server.address().port

--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -51,6 +51,8 @@ module.exports = JuliaClient =
   consumeToolBar: (bar) -> toolbar.consumeToolBar bar
 
   consumeGetServerConfig: (conf) -> @connection.consumeGetServerConfig(conf)
+  
+  consumeGetServerName: (name) -> @connection.consumeGetServerName(name)
 
   provideClient: -> @connection.client
 

--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -50,6 +50,8 @@ module.exports = JuliaClient =
 
   consumeToolBar: (bar) -> toolbar.consumeToolBar bar
 
+  consumeGetServerConfig: (conf) -> @connection.consumeGetServerConfig(conf)
+
   provideClient: -> @connection.client
 
   provideHyperclick: -> @runtime.provideHyperclick()

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -80,6 +80,7 @@ module.exports =
       'julia-client:start-julia': -> disrequireClient 'boot Julia', -> boot()
       'julia-client:kill-julia': -> juno.connection.client.kill()
       'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
+      'julia-client:disconnect-julia': => requireClient 'disconnect Julia', -> juno.connection.client.disconnect()
       # 'julia-client:reset-julia-server': -> juno.connection.local.server.reset() # server mode not functional
       'julia-client:connect-external-process': -> disrequireClient -> juno.connection.messages.connectExternal()
       'julia-client:connect-platformio-terminal': -> disrequireClient -> juno.connection.terminal.runPlatformIOTerm()

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -78,6 +78,7 @@ module.exports =
     @subs.add atom.commands.add 'atom-workspace',
       'julia-client:open-a-repl': -> juno.connection.terminal.repl()
       'julia-client:start-julia': -> disrequireClient 'boot Julia', -> boot()
+      'julia-client:start-remote-julia-process': -> disrequireClient 'boot a remote Julia process', -> juno.connection.bootRemote()
       'julia-client:kill-julia': -> juno.connection.client.kill()
       'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
       'julia-client:disconnect-julia': => requireClient 'disconnect Julia', -> juno.connection.client.disconnect()

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -191,7 +191,13 @@ config =
         title: 'Command to execute Julia on the remote server'
         type: 'string'
         default: 'julia'
-        order: 6
+        order: 1
+      tmux:
+        title: 'Use a persistent tmux session'
+        description: 'Requires tmux to be installed on the server you\'re connecting to.'
+        type: 'boolean'
+        default: false
+        order: 2
 
   firstBoot:
     type: 'boolean'

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -207,6 +207,11 @@ config =
         type: 'string'
         default: ''
         order: 4
+      usekeyfile:
+        title: 'Use a keyfile for identification'
+        type: 'boolean'
+        default: true
+        order: 4.5
       keyfile:
         title: 'Path to Keyfile'
         type: 'string'

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -13,7 +13,7 @@ config =
       bootMode:
         title: 'Boot Mode'
         type: 'string'
-        enum: ['Basic', 'Cycler']
+        enum: ['Basic', 'Cycler', 'Remote']
         default: 'Cycler'
         order: 1
       arguments:

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -183,6 +183,40 @@ config =
         default: false
         description: 'Enable this if you\'re experiencing slowdowns in the built-in terminals.'
         order: 9
+  remoteOptions:
+    type: 'object'
+    order: 5
+    properties:
+      server:
+        title: 'Server URL'
+        type: 'string'
+        default: ''
+        order: 1
+      port:
+        title: 'SSH Port'
+        type: 'number'
+        default: 22
+        order: 2
+      username:
+        title: 'Username'
+        type: 'string'
+        default: ''
+        order: 3
+      passphrase:
+        title: 'Passphrase'
+        type: 'string'
+        default: ''
+        order: 4
+      keyfile:
+        title: 'Path to Keyfile'
+        type: 'string'
+        default: ''
+        order: 5
+      remoteJulia:
+        title: 'Command to execute Julia on the remote server'
+        type: 'string'
+        default: 'julia'
+        order: 6
 
   firstBoot:
     type: 'boolean'

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -198,17 +198,22 @@ config =
         type: 'boolean'
         default: false
         order: 2
+      tmuxName:
+        title: 'tmux session name'
+        type: 'string'
+        default: 'juno_tmux_session'
+        order: 3
       agentAuth:
         title: 'Use SSH agent'
         description: 'Requires `$SSH_AUTH_SOCKET` to be set. Defaults to putty\'s pageant on Windows'
         type: 'boolean'
         default: true
-        order: 3
+        order: 4
       forwardAgent:
         title: 'Forward SSH agent'
         type: 'boolean'
         default: true
-        order: 4
+        order: 5
 
   firstBoot:
     type: 'boolean'

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -198,6 +198,17 @@ config =
         type: 'boolean'
         default: false
         order: 2
+      agentAuth:
+        title: 'Use SSH agent'
+        description: 'Requires `$SSH_AUTH_SOCKET` to be set. Defaults to putty\'s pageant on Windows'
+        type: 'boolean'
+        default: true
+        order: 3
+      forwardAgent:
+        title: 'Forward SSH agent'
+        type: 'boolean'
+        default: true
+        order: 4
 
   firstBoot:
     type: 'boolean'

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -187,36 +187,6 @@ config =
     type: 'object'
     order: 5
     properties:
-      server:
-        title: 'Server URL'
-        type: 'string'
-        default: ''
-        order: 1
-      port:
-        title: 'SSH Port'
-        type: 'number'
-        default: 22
-        order: 2
-      username:
-        title: 'Username'
-        type: 'string'
-        default: ''
-        order: 3
-      passphrase:
-        title: 'Passphrase'
-        type: 'string'
-        default: ''
-        order: 4
-      usekeyfile:
-        title: 'Use a keyfile for identification'
-        type: 'boolean'
-        default: true
-        order: 4.5
-      keyfile:
-        title: 'Path to Keyfile'
-        type: 'string'
-        default: ''
-        order: 5
       remoteJulia:
         title: 'Command to execute Julia on the remote server'
         type: 'string'

--- a/lib/package/toolbar.coffee
+++ b/lib/package/toolbar.coffee
@@ -28,6 +28,14 @@ module.exports =
 
     @bar.addSpacer()
 
+    @bar.addButton
+      icon: 'planet'
+      callback: 'julia-client:start-remote-julia-process'
+      tooltip: 'Start Remote Julia Process'
+      iconset: 'ion'
+
+    @bar.addSpacer()
+
     # Windows & Panes
 
     @bar.addButton

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -8,6 +8,8 @@ import modules from './modules'
 import * as pty from 'node-pty-prebuilt'
 import { debounce, once } from 'underscore-plus'
 import { customSelector } from '../ui'
+import { getConnectionSettings } from '../connection/process/remote'
+import * as ssh from 'ssh2'
 
 var { changeprompt, changemodule, resetprompt, validatepath, fullpath } =
       client.import({msg: ['changeprompt', 'changemodule', 'resetprompt'], rpc: ['validatepath', 'fullpath']})
@@ -136,6 +138,19 @@ export function activate (ink) {
     }).catch((e) => console.error(e))
   }))
 
+  subs.add(atom.commands.add('atom-workspace', 'julia-client:new-remote-terminal', () => {
+    let term = ink.InkTerminal.fromId(`remote-terminal-julia-${Math.floor(Math.random()*10000000)}`, {
+      scrollback: atom.config.get('julia-client.consoleOptions.maximumConsoleSize'),
+      cursorStyle: atom.config.get('julia-client.consoleOptions.cursorStyle'),
+      rendererType: atom.config.get('julia-client.consoleOptions.rendererType') ? 'dom' : 'canvas'
+    })
+    term.attachCustomKeyEventHandler(handleWhitelistedKeybindingTerminal)
+    remotePty().then(({pty, cwd}) => {
+      term.attach(pty, true, cwd)
+      term.open().then(() => term.show())
+    }).catch((e) => console.error(e))
+  }))
+
   subs.add(atom.workspace.onDidStopChangingActivePaneItem(item => {
     if (item && item.id && item.name === 'InkTerminal' && item.element.initialized) {
       let rt = atom.config.get('julia-client.consoleOptions.rendererType')
@@ -170,6 +185,26 @@ function handleWhitelistedKeybindingTerminal (e) {
     return false
   }
   return e
+}
+
+function remotePty () {
+  return new Promise((resolve, reject) => {
+    let conn = new ssh.Client()
+    conn.on('ready', () => {
+      conn.shell((err, stream) => {
+        if (err) console.error(`Error while starting remote shell.`)
+
+        stream.on('close', () => {
+          conn.end()
+        })
+
+        // forward resize handling
+        stream.resize = (cols, rows) => stream.setWindow(rows, cols, 999, 999)
+
+        resolve({pty: stream, cwd: '~'})
+      })
+    }).connect(getConnectionSettings())
+  })
 }
 
 function shellPty (cwd) {

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -197,7 +197,7 @@ function remotePty () {
     return new Promise((resolve, reject) => {
       let conn = new ssh.Client()
       conn.on('ready', () => {
-        conn.shell((err, stream) => {
+        conn.shell({ term: "xterm-256color" }, (err, stream) => {
           if (err) console.error(`Error while starting remote shell.`)
 
           stream.on('close', () => {

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -149,6 +149,7 @@ export function activate (ink) {
       term.attach(pty, true, cwd)
       term.setTitle(`Terminal @ ${conf.name}`)
       term.open().then(() => term.show())
+      pty.on('close', () => term.detach())
     }).catch((e) => console.error(e))
   }))
 

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -105,6 +105,9 @@ export function activate (ink) {
 
   client.onDetached(() => {
     terminal.detach()
+    // make sure to switch to the normal termbuffer, otherweise there might be
+    // issues when leaving an xterm session:
+    terminal.write('\x1b[?1049l')
     terminal.write('\n\r\x1b[1m\r\x1b[31mJulia has exited.\x1b[0m Press Enter to start a new session.\n\r')
     terminal.terminal.deregisterLinkMatcher(linkHandler)
     if (promptObserver) promptObserver.dispose()

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -142,7 +142,7 @@ export function activate (ink) {
   }))
 
   subs.add(atom.commands.add('atom-workspace', 'julia-client:new-remote-terminal', () => {
-    let term = ink.InkTerminal.fromId(`remote-terminal-julia-${Math.floor(Math.random()*10000000)}`, {
+    let term = ink.InkTerminal.fromId(`terminal-remote-julia-${Math.floor(Math.random()*10000000)}`, {
       scrollback: atom.config.get('julia-client.consoleOptions.maximumConsoleSize'),
       cursorStyle: atom.config.get('julia-client.consoleOptions.cursorStyle'),
       rendererType: atom.config.get('julia-client.consoleOptions.rendererType') ? 'dom' : 'canvas'
@@ -167,19 +167,20 @@ export function activate (ink) {
   }))
 
   // handle deserialized terminals
-  forEachTerminalPane(item => {
+  forEachPane(item => {
     if (!item.ty) {
       item.attachCustomKeyEventHandler(handleWhitelistedKeybindingTerminal)
       shellPty(item.persistentState.cwd)
         .then(({pty, cwd}) => item.attach(pty, true, cwd))
         .catch(() => {})
     }
-  })
+  }, /terminal\-julia\-\d+/)
+  forEachPane(item => item.close(), /terminal\-remote\-julia\-\d+/)
 }
 
-function forEachTerminalPane (f) {
+function forEachPane (f, id = /terminal\-julia\-\d+/) {
   atom.workspace.getPaneItems().forEach((item) => {
-    if (item.id && item.name === 'InkTerminal' && item.id.match(/terminal\-julia\-\d+/)) {
+    if (item.id && item.name === 'InkTerminal' && item.id.match(id)) {
       f(item)
     }
   })
@@ -244,11 +245,12 @@ function shellPty (cwd) {
 
 export function deactivate () {
   // detach node-pty process from ink terminals; necessary for updates to work cleanly
-  atom.workspace.getPaneItems().forEach((item) => {
-    if (item.id && item.name === 'InkTerminal' && item.id.match(/terminal\-julia\-\d+/)) {
-      item.detach()
-    }
-  })
+  forEachPane(item => item.detach(), /terminal\-julia\-\d+/)
+  // remote terminals shouldn't be serialized
+  forEachPane(item => {
+    item.detach()
+    item.close()
+  }, /terminal\-remote\-julia\-\d+/)
   terminal.detach()
 
   if (subs) subs.dispose()

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -147,6 +147,7 @@ export function activate (ink) {
     term.attachCustomKeyEventHandler(handleWhitelistedKeybindingTerminal)
     remotePty().then(({pty, cwd}) => {
       term.attach(pty, true, cwd)
+      term.setTitle(`Terminal @ ${getConnectionSettings().host}`)
       term.open().then(() => term.show())
     }).catch((e) => console.error(e))
   }))

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -8,7 +8,7 @@ import modules from './modules'
 import * as pty from 'node-pty-prebuilt'
 import { debounce, once } from 'underscore-plus'
 import { customSelector } from '../ui'
-import { getConnectionSettings } from '../connection/process/remote'
+import { withRemoteConfig } from '../connection/process/remote'
 import * as ssh from 'ssh2'
 
 var { changeprompt, changemodule, resetprompt, validatepath, fullpath } =
@@ -145,9 +145,9 @@ export function activate (ink) {
       rendererType: atom.config.get('julia-client.consoleOptions.rendererType') ? 'dom' : 'canvas'
     })
     term.attachCustomKeyEventHandler(handleWhitelistedKeybindingTerminal)
-    remotePty().then(({pty, cwd}) => {
+    remotePty().then(({pty, cwd, conf}) => {
       term.attach(pty, true, cwd)
-      term.setTitle(`Terminal @ ${getConnectionSettings().host}`)
+      term.setTitle(`Terminal @ ${conf.name}`)
       term.open().then(() => term.show())
     }).catch((e) => console.error(e))
   }))
@@ -189,22 +189,24 @@ function handleWhitelistedKeybindingTerminal (e) {
 }
 
 function remotePty () {
-  return new Promise((resolve, reject) => {
-    let conn = new ssh.Client()
-    conn.on('ready', () => {
-      conn.shell((err, stream) => {
-        if (err) console.error(`Error while starting remote shell.`)
+  return withRemoteConfig(conf => {
+    return new Promise((resolve, reject) => {
+      let conn = new ssh.Client()
+      conn.on('ready', () => {
+        conn.shell((err, stream) => {
+          if (err) console.error(`Error while starting remote shell.`)
 
-        stream.on('close', () => {
-          conn.end()
+          stream.on('close', () => {
+            conn.end()
+          })
+
+          // forward resize handling
+          stream.resize = (cols, rows) => stream.setWindow(rows, cols, 999, 999)
+
+          resolve({pty: stream, cwd: '~', conf: conf})
         })
-
-        // forward resize handling
-        stream.resize = (cols, rows) => stream.setWindow(rows, cols, 999, 999)
-
-        resolve({pty: stream, cwd: '~'})
-      })
-    }).connect(getConnectionSettings())
+      }).connect(conf)
+    })
   })
 }
 

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -15,7 +15,7 @@ module.exports =
   currentContext: ->
     editor = atom.workspace.getActiveTextEditor()
     mod = modules.current() ? 'Main'
-    edpath = editor.getPath() || 'untitled-' + editor.getBuffer().id
+    edpath = client.editorPath(editor) || 'untitled-' + editor.getBuffer().id
     {editor, mod, edpath}
 
   eval: ({move, cell}={}) ->
@@ -124,7 +124,7 @@ module.exports =
   # Working Directory
 
   cdHere: ->
-    file = atom.workspace.getActiveTextEditor()?.getPath()
+    file = client.editorPath(atom.workspace.getActiveTextEditor()?)
     if !file then atom.notifications.addError 'This file has no path.'
     cd path.dirname(file)
 

--- a/lib/runtime/modules.coffee
+++ b/lib/runtime/modules.coffee
@@ -98,7 +98,7 @@ module.exports =
     sels = ed.getSelections()
     {row, column} = sels[sels.length - 1].getBufferRange().end
     data =
-      path: ed.getPath()
+      path: client.editorPath(ed)
       code: ed.getText()
       row: row+1, column: column+1
       module: ed.juliaModule

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     },
     "ftp-remote.getCurrentServerConfig": {
       "versions": {
-        "*": "consumeGetServerConfig"
+        "0.1.0": "consumeGetServerConfig"
       }
     },
     "ftp-remote.getCurrentServerName": {
       "versions": {
-        "*": "consumeGetServerName"
+        "0.1.0": "consumeGetServerName"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,11 @@
       "versions": {
         "*": "consumeTerminal"
       }
+    },
+    "ftp-remote.getCurrentServerConfig": {
+      "versions": {
+        "*": "consumeGetServerConfig"
+      }
     }
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "coffee-script": "*",
     "physical-cpu-count": "*",
     "node-pty-prebuilt": "0.7.6",
+    "ssh2": "*",
+    "fuzzaldrin-plus": "^0.6.0",
     "etch": "*"
   },
   "consumedServices": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
       "versions": {
         "*": "consumeGetServerConfig"
       }
+    },
+    "ftp-remote.getCurrentServerName": {
+      "versions": {
+        "*": "consumeGetServerName"
+      }
     }
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "coffee-script": "*",
     "physical-cpu-count": "*",
     "node-pty-prebuilt": "0.7.6",
-    "ssh2": "*",
+    "ssh2": "^0.6.0",
     "fuzzaldrin-plus": "^0.6.0",
     "etch": "*"
   },

--- a/script/boot_repl.jl
+++ b/script/boot_repl.jl
@@ -12,22 +12,7 @@ junorc = abspath(normpath(expanduser(junorc)))
 
 if (VERSION > v"0.7-" ? Base.find_package("Atom") : Base.find_in_path("Atom")) == nothing
   p = VERSION > v"0.7-" ? (x) -> printstyled(x, color=:cyan, bold=true) : (x) -> print_with_color(:cyan, x, bold=true)
-  p("\nHold on tight while we're installing some packages for you.\nThis should only take a few seconds...\n\n")
-
-  if VERSION > v"0.7-"
-    using Pkg
-    Pkg.activate()
-  end
-
-  Pkg.add("Atom")
-  Pkg.add("Juno")
-
-  println()
-end
-
-if (VERSION > v"0.7-" ? Base.find_package("Atom") : Base.find_in_path("Atom")) == nothing
-  p = VERSION > v"0.7-" ? (x) -> printstyled(x, color=:cyan, bold=true) : (x) -> print_with_color(:cyan, x, bold=true)
-  p("\nHold on tight while we're installing some packages for you.\nThis should only take a few seconds...\n\n")
+  p("\nHold on tight while we are installing some packages for you.\nThis should only take a few seconds...\n\n")
 
   if VERSION > v"0.7-"
     using Pkg


### PR DESCRIPTION
Still lots to do...

- [x] Stop storing passphrase/password in plaintext
- [x] Don't try to `cd` into a local path on startup
- [x] Support for multiple servers.
- [x] Fix interrupts. Kinda works now, but a general solution probably isn't possible since many ssh servers don't implement signal forwarding apparently. 
- [x] Error handling!
- [x] Option for persistent julia process on server.
- [x] Disconnect handling.
- [x] Fix path issues on remote machine
- [ ] Better disconnect handling.
- [ ] Support for more complex ssh setups.
- [ ] Per-server config.

Also needs https://github.com/JunoLab/atom-ink/pull/184 and https://github.com/h3imdall/ftp-remote-edit/pull/228.