### PR TITLE
Recover `focus-last-editor/terminal` functionality

### DIFF
--- a/lib/ui/focusutils.js
+++ b/lib/ui/focusutils.js
@@ -4,9 +4,8 @@ import {TextEditor} from 'atom'
 
 let lastEditor
 let lastTerminal
-let listener
+let listner
 let commands
-let ink
 
 function clamp (x, min, max) {
   return Math.min(Math.max(x, min), max)
@@ -36,12 +35,12 @@ class FocusHistory {
   }
 
   moveBack () {
-    let item = this.history.pop()
+    const item = this.history.pop()
     if (item && item.open) {
       const activeItem = atom.workspace.getActivePaneItem()
       if (activeItem instanceof TextEditor) {
-        let file = activeItem.getPath() || 'untitled-' + activeItem.buffer.getId()
-        let line = activeItem.getCursorBufferPosition().row
+        const file = activeItem.getPath() || 'untitled-' + activeItem.buffer.getId()
+        const line = activeItem.getCursorBufferPosition().row
         this.openedItem = {file, line}
       }
       item.open()
@@ -50,7 +49,7 @@ class FocusHistory {
 }
 
 export function activate (i) {
-  listener = atom.workspace.onDidStopChangingActivePaneItem((item) => {
+  listner = atom.workspace.onDidStopChangingActivePaneItem((item) => {
     if (item instanceof TextEditor) {
       lastEditor = item
     } else if (item instanceof i.InkTerminal) {
@@ -58,9 +57,8 @@ export function activate (i) {
     }
   })
 
-  ink = i
-  let history = new FocusHistory(30)
-
+  const ink = i
+  const history = new FocusHistory(30)
   ink.Opener.onDidOpen(({newLocation, oldLocation}) => {
     if (oldLocation) history.push(oldLocation)
   })
@@ -72,15 +70,8 @@ export function activate (i) {
   })
 }
 
-function getPane (item) {
-  for (let pane of atom.workspace.getPanes()) {
-    if (pane.getItems().includes(item)) {
-      return pane
-    }
-  }
-}
-
 export function deactivate () {
+  listner.dispose()
   commands.dispose()
 }
 
@@ -89,7 +80,7 @@ export function deactivate () {
 // }
 
 function focusLastEditor () {
-  let pane = getPane(lastEditor)
+  const pane = atom.workspace.paneForItem(lastEditor)
   if (pane) {
     pane.activate()
     pane.activateItem(lastEditor)

--- a/lib/ui/focusutils.js
+++ b/lib/ui/focusutils.js
@@ -4,7 +4,7 @@ import {TextEditor, CompositeDisposable} from 'atom'
 
 let lastEditor
 let lastTerminal
-let subs = new CompositeDisposable
+let subs = new CompositeDisposable()
 
 class FocusHistory {
   constructor (size) {
@@ -43,16 +43,15 @@ class FocusHistory {
   }
 }
 
-export function activate (i) {
+export function activate (ink) {
   subs.add(atom.workspace.onDidStopChangingActivePaneItem((item) => {
     if (item instanceof TextEditor) {
       lastEditor = item
-    } else if (item instanceof i.InkTerminal) {
+    } else if (item instanceof ink.InkTerminal) {
       lastTerminal = item
     }
   }))
 
-  const ink = i
   const history = new FocusHistory(30)
   ink.Opener.onDidOpen(({newLocation, oldLocation}) => {
     if (oldLocation) history.push(oldLocation)

--- a/lib/ui/focusutils.js
+++ b/lib/ui/focusutils.js
@@ -6,10 +6,6 @@ let lastEditor
 let lastTerminal
 let subs = new CompositeDisposable
 
-function clamp (x, min, max) {
-  return Math.min(Math.max(x, min), max)
-}
-
 class FocusHistory {
   constructor (size) {
     this.size = size
@@ -76,10 +72,6 @@ export function deactivate () {
   subs = null
 }
 
-// export function lastEditor () {
-//   return lastEditor
-// }
-
 function focusLastEditor () {
   const pane = atom.workspace.paneForItem(lastEditor)
   if (pane) {
@@ -87,10 +79,6 @@ function focusLastEditor () {
     pane.activateItem(lastEditor)
   }
 }
-
-// export function lastTerminal () {
-//   return lastTerminal
-// }
 
 function focusLastTerminal () {
   if (lastTerminal && lastTerminal.open) lastTerminal.open()

--- a/lib/ui/focusutils.js
+++ b/lib/ui/focusutils.js
@@ -50,6 +50,14 @@ class FocusHistory {
 }
 
 export function activate (i) {
+  listener = atom.workspace.onDidStopChangingActivePaneItem((item) => {
+    if (item instanceof TextEditor) {
+      lastEditor = item
+    } else if (item instanceof i.InkTerminal) {
+      lastTerminal = item
+    }
+  })
+
   ink = i
   let history = new FocusHistory(30)
 
@@ -76,9 +84,9 @@ export function deactivate () {
   commands.dispose()
 }
 
-export function lastEditor () {
-  return lastEditor
-}
+// export function lastEditor () {
+//   return lastEditor
+// }
 
 function focusLastEditor () {
   let pane = getPane(lastEditor)
@@ -88,9 +96,9 @@ function focusLastEditor () {
   }
 }
 
-export function lastTerminal () {
-  return lastTerminal
-}
+// export function lastTerminal () {
+//   return lastTerminal
+// }
 
 function focusLastTerminal () {
   if (lastTerminal && lastTerminal.open) lastTerminal.open()

--- a/lib/ui/focusutils.js
+++ b/lib/ui/focusutils.js
@@ -1,11 +1,10 @@
 'use babel'
 
-import {TextEditor} from 'atom'
+import {TextEditor, CompositeDisposable} from 'atom'
 
 let lastEditor
 let lastTerminal
-let listner
-let commands
+let subs = new CompositeDisposable
 
 function clamp (x, min, max) {
   return Math.min(Math.max(x, min), max)
@@ -49,13 +48,13 @@ class FocusHistory {
 }
 
 export function activate (i) {
-  listner = atom.workspace.onDidStopChangingActivePaneItem((item) => {
+  subs.add(atom.workspace.onDidStopChangingActivePaneItem((item) => {
     if (item instanceof TextEditor) {
       lastEditor = item
     } else if (item instanceof i.InkTerminal) {
       lastTerminal = item
     }
-  })
+  }))
 
   const ink = i
   const history = new FocusHistory(30)
@@ -63,16 +62,18 @@ export function activate (i) {
     if (oldLocation) history.push(oldLocation)
   })
 
-  commands = atom.commands.add('atom-workspace', {
+  subs.add(atom.commands.add('atom-workspace', {
     'julia-client:focus-last-editor': () => focusLastEditor(),
     'julia-client:focus-last-terminal': () => focusLastTerminal(),
     'julia-client:return-from-goto': () => history.moveBack()
-  })
+  }))
 }
 
 export function deactivate () {
-  listner.dispose()
-  commands.dispose()
+  lastEditor = null
+  lastTerminal = null
+  subs.dispose()
+  subs = null
 }
 
 // export function lastEditor () {


### PR DESCRIPTION
The commit [add `return-from-goto` command](https://github.com/JunoLab/atom-julia-client/commit/6223ca68efd8fc1832d4321844858808b97eaa3a) removes the functionality for `julia-client:focus-last-editor` and `julia-client:focus-last-terminal`.

I'm not sure this is an intentional change, but I believe this functionality should be so much useful for some users that I recovered it.

I also refactored the file a bit with following changes:
- Add identifiers to variables (suggested by eslint)
- Removed unused functions (grep-based check for usages in the whole project)
- Use Atom `CompositeDisposable` for disposer