### PR TITLE
Feature - Add custom layout options

### DIFF
--- a/lib/connection/process/basic.coffee
+++ b/lib/connection/process/basic.coffee
@@ -60,7 +60,7 @@ module.exports =
 
   # Windows Stuff
 
-  wrapperEnabled: -> atom.config.get "julia-client.enablePowershellWrapper"
+  wrapperEnabled: -> atom.config.get "julia-client.juliaOptions.enablePowershellWrapper"
 
   sendSignalToWrapper: (signal, port) ->
     wrapper = net.connect({port})

--- a/lib/connection/process/basic2.js
+++ b/lib/connection/process/basic2.js
@@ -81,7 +81,7 @@ function getUnix (path, args, env) {
 }
 
 function getWindows (path, args, env) {
-  if (!atom.config.get('julia-client.enablePowershellWrapper')) {
+  if (!atom.config.get('julia-client.juliaOptions.enablePowershellWrapper')) {
     return getUnix(path, args, env)
   }
   return new Promise((resolve, reject) => {

--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -1,7 +1,9 @@
 etch = require 'etch'
 
 commands = require './package/commands'
+config = require './package/config'
 menu = require './package/menu'
+settings = require './package/settings'
 toolbar = require './package/toolbar'
 
 module.exports = JuliaClient =
@@ -17,7 +19,7 @@ module.exports = JuliaClient =
       x.activate() for x in [menu, @connection, @runtime]
       @ui.activate @connection.client
 
-      require('./package/settings').updateSettings()
+      settings.updateSettings()
 
       if atom.config.get('julia-client.firstBoot')
         @ui.layout.queryStandardLayout()
@@ -34,6 +36,8 @@ module.exports = JuliaClient =
             detail: 'Julia Client requires the Ink package to run.
                      Please install it manually from the settings view.'
             dismissable: true
+
+  config: config
 
   deactivate: ->
     x.deactivate() for x in [commands, menu, toolbar, @connection, @runtime, @ui]
@@ -58,5 +62,4 @@ module.exports = JuliaClient =
 
   provideHyperclick: -> @runtime.provideHyperclick()
 
-  config: require './package/config'
   completions: -> @runtime.completions

--- a/lib/julia-client.coffee
+++ b/lib/julia-client.coffee
@@ -22,9 +22,10 @@ module.exports = JuliaClient =
       settings.updateSettings()
 
       if atom.config.get('julia-client.firstBoot')
-        @ui.layout.queryStandardLayout()
-      if atom.config.get('julia-client.uiOptions.useStandardLayout')
-        setTimeout (=> @ui.layout.standard()), 150
+        @ui.layout.queryDefaultLayout()
+      else
+        if atom.config.get('julia-client.uiOptions.layouts.openDefaultPanesOnStartUp')
+          setTimeout (=> @ui.layout.defaultLayout()), 150
 
   requireInk: (fn) ->
     if atom.packages.isPackageLoaded "ink" then fn()

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -29,10 +29,10 @@ module.exports =
           boot()
           juno.runtime.evaluation.evalAll()
       'julia-client:run-weave-chunks': (event) =>
-          cancelComplete event
-          @withInk ->
-            boot()
-            juno.runtime.evaluation.evalAllWeaveChunks()
+        cancelComplete event
+        @withInk ->
+          boot()
+          juno.runtime.evaluation.evalAllWeaveChunks()
       'julia-client:run-cell': =>
         @withInk ->
           boot()
@@ -100,7 +100,7 @@ module.exports =
       'julia-debug:stop-debugging': => juno.runtime.debugger.stop()
       'julia-debug:finish-function': => juno.runtime.debugger.finish()
       'julia-debug:continue': => juno.runtime.debugger.continueForward()
-      'julia-debug:open-debugger-pane': => juno.runtime.debugger.openPane()
+      'julia-debug:open-debugger-pane': => juno.runtime.debugger.open()
 
       'julia:open-julia-startup-file': -> atom.workspace.open(juno.misc.paths.home('.julia', 'config', 'startup.jl'))
       'julia:open-juno-startup-file': -> atom.workspace.open(juno.misc.paths.home('.julia', 'config', 'juno_startup.jl'))

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -89,6 +89,7 @@ module.exports =
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()
       'julia-client:open-workspace': => @withInk -> juno.runtime.workspace.open()
       'julia-client:default-layout': -> juno.ui.layout.defaultLayout()
+      'julia-client:reset-layout-settings': -> juno.ui.layout.resetLayoutSettings()
       'julia-client:settings': -> atom.workspace.open('atom://config/packages/julia-client')
       'julia-debug:toggle-breakpoint': => juno.runtime.debugger.togglebp()
       'julia-debug:toggle-conditional-breakpoint': => juno.runtime.debugger.togglebp(true)

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -88,6 +88,7 @@ module.exports =
       'julia-client:connect-terminal': -> disrequireClient -> juno.connection.terminal.connectedRepl()
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()
       'julia-client:open-workspace': => @withInk -> juno.runtime.workspace.open()
+      'julia-client:default-layout': -> juno.ui.layout.defaultLayout()
       'julia-client:settings': -> atom.workspace.open('atom://config/packages/julia-client')
       'julia-debug:toggle-breakpoint': => juno.runtime.debugger.togglebp()
       'julia-debug:toggle-conditional-breakpoint': => juno.runtime.debugger.togglebp(true)
@@ -106,7 +107,6 @@ module.exports =
       'julia:open-julia-home': -> shell.openItem juno.misc.paths.juliaHome()
       'julia:open-package-in-new-window': -> requireClient 'get packages', -> juno.runtime.packages.openPackage()
       'julia:open-package-as-project-folder': -> requireClient 'get packages', -> juno.runtime.packages.openPackage(false)
-      'julia:standard-layout': -> juno.ui.layout.standard()
       'julia:get-help': -> shell.openExternal 'http://discourse.julialang.org'
 
       'julia-client:work-in-file-folder': ->

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -150,12 +150,178 @@ config =
         type: 'boolean'
         default: false
         order: 9
+      customLayoutOptions:
+        title: 'Custom Layout Options'
+        type: 'object'
+        order: 10
+        collapsed: true
+        properties:
+          console:
+            title: 'Console'
+            type: 'object'
+            order: 1
+            collapsed: true
+            properties:
+              defaultLocation:
+                title: 'Default location of Console Pane'
+                type: 'string'
+                enum: ['center', 'left', 'bottom', 'right']
+                default: 'bottom'
+                radio: true
+                order: 1
+              split:
+                title: 'How to split Console Pane'
+                type: 'string'
+                enum: ['no split', 'left', 'up', 'right', 'down']
+                default: 'no split'
+                radio: true
+                order: 2
+          terminal:
+            title: 'Terminal'
+            type: 'object'
+            order: 2
+            collapsed: true
+            properties:
+              defaultLocation:
+                title: 'Default location of Terminal Pane'
+                type: 'string'
+                enum: ['center', 'left', 'bottom', 'right']
+                default: 'bottom'
+                radio: true
+                order: 1
+              split:
+                title: 'How to split Terminal Pane'
+                type: 'string'
+                enum: ['no split', 'left', 'up', 'right', 'down']
+                default: 'no split'
+                radio: true
+                order: 2
+          workspace:
+            title: 'Workspace'
+            type: 'object'
+            order: 3
+            collapsed: true
+            properties:
+              defaultLocation:
+                title: 'Default location of Workspace Pane'
+                type: 'string'
+                enum: ['center', 'left', 'bottom', 'right']
+                default: 'center'
+                radio: true
+                order: 1
+              split:
+                title: 'How to split Workspace Pane'
+                type: 'string'
+                enum: ['no split', 'left', 'up', 'right', 'down']
+                default: 'right'
+                radio: true
+                order: 2
+          documentation:
+            title: 'Documentation Browser'
+            type: 'object'
+            order: 4
+            collapsed: true
+            properties:
+              defaultLocation:
+                title: 'Default location of Documentation Browser Pane'
+                type: 'string'
+                enum: ['center', 'left', 'bottom', 'right']
+                default: 'right'
+                radio: true
+                order: 1
+              split:
+                title: 'How to split Documentation Browser Pane'
+                type: 'string'
+                enum: ['no split', 'left', 'up', 'right', 'down']
+                default: 'no split'
+                radio: true
+                order: 2
+          plotPane:
+            title: 'Plot Pane'
+            type: 'object'
+            order: 5
+            collapsed: true
+            properties:
+              defaultLocation:
+                title: 'Default location of Plot Pane'
+                type: 'string'
+                enum: ['center', 'left', 'bottom', 'right']
+                default: 'center'
+                radio: true
+                order: 1
+              split:
+                title: 'How to split Plot Pane'
+                type: 'string'
+                enum: ['no split', 'left', 'up', 'right', 'down']
+                default: 'right'
+                radio: true
+                order: 2
+          debuggerPane:
+            title: 'Debugger Pane'
+            type: 'object'
+            order: 6
+            collapsed: true
+            properties:
+              defaultLocation:
+                title: 'Default location of Debugger Pane'
+                type: 'string'
+                enum: ['center', 'left', 'bottom', 'right']
+                default: 'right'
+                radio: true
+                order: 1
+              split:
+                title: 'How to split Debugger Pane'
+                type: 'string'
+                enum: ['no split', 'left', 'up', 'right', 'down']
+                default: 'no split'
+                radio: true
+                order: 2
+          profiler:
+            title: 'Profiler'
+            type: 'object'
+            order: 7
+            collapsed: true
+            properties:
+              defaultLocation:
+                title: 'Default location of Profiler Pane'
+                type: 'string'
+                enum: ['center', 'left', 'bottom', 'right']
+                default: 'center'
+                radio: true
+                order: 1
+              split:
+                title: 'How to split Profiler Pane'
+                type: 'string'
+                enum: ['no split', 'left', 'up', 'right', 'down']
+                default: 'right'
+                radio: true
+                order: 2
+          linter:
+            title: 'Linter'
+            type: 'object'
+            order: 8
+            collapsed: true
+            properties:
+              defaultLocation:
+                title: 'Default location of Linter Pane'
+                type: 'string'
+                enum: ['center', 'left', 'bottom', 'right']
+                default: 'bottom'
+                radio: true
+                order: 1
+              split:
+                title: 'How to split Linter Pane'
+                type: 'string'
+                enum: ['no split', 'left', 'up', 'right', 'down']
+                default: 'no split'
+                radio: true
+                order: 2
       noAutoParenthesis:
         title: 'Don\'t Insert Parenthesis on Function Autocompletion'
         description: 'Juno will not insert parenthesis after completing a function if this is enabled.'
         type: 'boolean'
         default: false
-        order: 10
+        order: 11
   consoleOptions:
     type: 'object'
     order: 4

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -226,14 +226,14 @@ config =
                 title: 'Default location of Documentation Browser Pane'
                 type: 'string'
                 enum: ['center', 'left', 'bottom', 'right']
-                default: 'right'
+                default: 'center'
                 radio: true
                 order: 1
               split:
                 title: 'Splitting rule of Documentation Browser Pane'
                 type: 'string'
                 enum: ['no split', 'left', 'up', 'right', 'down']
-                default: 'no split'
+                default: 'right'
                 radio: true
                 order: 2
           plotPane:

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -151,16 +151,10 @@ config =
         default: ['##', '#---', '#%%', '# %%']
         description: 'Regular expressions for determining cell delimiters.'
         order: 9
-      useStandardLayout:
-        title: 'Restore Standard Layout on Start'
-        type: 'boolean'
-        default: false
-        order: 10
       layouts:
         title: 'Layout'
         type: 'object'
-        order: 11
-        collapsed: true
+        order: 10
         properties:
           console:
             title: 'Console'
@@ -322,6 +316,51 @@ config =
                 default: 'no split'
                 radio: true
                 order: 2
+          defaultPanes:
+            title: 'Default Panes'
+            description: 'Specify panes that are opened by `Julia-Client:Default-Layout`.
+                          Default location and rule of splitting follow the settings above.'
+            type: 'object'
+            order: 9
+            properties:
+              console:
+                title: 'Console'
+                type: 'boolean'
+                default: true
+                order: 1
+              workspace:
+                title: 'Workspace'
+                type: 'boolean'
+                default: true
+                order: 2
+              documentation:
+                title: 'Documentation Browser'
+                type: 'boolean'
+                default: true
+                order: 3
+              plotPane:
+                title: 'Plot Pane'
+                type: 'boolean'
+                default: true
+                order: 4
+              debuggerPane:
+                title: 'Debugger Pane'
+                type: 'boolean'
+                default: false
+                order: 5
+              linter:
+                title: 'Linter'
+                type: 'boolean'
+                default: false
+                order: 6
+          openDefaultPanesOnStartUp:
+            title: 'Open Default Panes on Startup'
+            description: 'If enabled, opens panes specified above on startup.
+                          If there are the panes restored from a previous window state,
+                          the pane would stay there.'
+            type: 'boolean'
+            default: true
+            order: 10
   consoleOptions:
     type: 'object'
     order: 4

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -170,7 +170,7 @@ config =
                 radio: true
                 order: 1
               split:
-                title: 'How to split Console Pane'
+                title: 'Splitting rule of Console Pane'
                 type: 'string'
                 enum: ['no split', 'left', 'up', 'right', 'down']
                 default: 'no split'
@@ -190,7 +190,7 @@ config =
                 radio: true
                 order: 1
               split:
-                title: 'How to split Terminal Pane'
+                title: 'Splitting rule of Terminal Pane'
                 type: 'string'
                 enum: ['no split', 'left', 'up', 'right', 'down']
                 default: 'no split'
@@ -210,7 +210,7 @@ config =
                 radio: true
                 order: 1
               split:
-                title: 'How to split Workspace Pane'
+                title: 'Splitting rule of Workspace Pane'
                 type: 'string'
                 enum: ['no split', 'left', 'up', 'right', 'down']
                 default: 'right'
@@ -230,7 +230,7 @@ config =
                 radio: true
                 order: 1
               split:
-                title: 'How to split Documentation Browser Pane'
+                title: 'Splitting rule of Documentation Browser Pane'
                 type: 'string'
                 enum: ['no split', 'left', 'up', 'right', 'down']
                 default: 'no split'
@@ -250,7 +250,7 @@ config =
                 radio: true
                 order: 1
               split:
-                title: 'How to split Plot Pane'
+                title: 'Splitting rule of Plot Pane'
                 type: 'string'
                 enum: ['no split', 'left', 'up', 'right', 'down']
                 default: 'right'
@@ -270,7 +270,7 @@ config =
                 radio: true
                 order: 1
               split:
-                title: 'How to split Debugger Pane'
+                title: 'Splitting rule of Debugger Pane'
                 type: 'string'
                 enum: ['no split', 'left', 'up', 'right', 'down']
                 default: 'no split'
@@ -290,7 +290,7 @@ config =
                 radio: true
                 order: 1
               split:
-                title: 'How to split Profiler Pane'
+                title: 'Splitting rule of Profiler Pane'
                 type: 'string'
                 enum: ['no split', 'left', 'up', 'right', 'down']
                 default: 'right'
@@ -310,7 +310,7 @@ config =
                 radio: true
                 order: 1
               split:
-                title: 'How to split Linter Pane'
+                title: 'Splitting rule of Linter Pane'
                 type: 'string'
                 enum: ['no split', 'left', 'up', 'right', 'down']
                 default: 'no split'
@@ -319,7 +319,7 @@ config =
           defaultPanes:
             title: 'Default Panes'
             description: 'Specify panes that are opened by `Julia-Client:Default-Layout`.
-                          Default location and rule of splitting follow the settings above.'
+                          Default location and splitting rule follow the settings above.'
             type: 'object'
             order: 9
             properties:
@@ -357,7 +357,7 @@ config =
             title: 'Open Default Panes on Startup'
             description: 'If enabled, opens panes specified above on startup.
                           If there are the panes restored from a previous window state,
-                          the pane would stay there.'
+                          the pane would still stay there.'
             type: 'boolean'
             default: true
             order: 10
@@ -385,7 +385,8 @@ config =
         title: 'Shell'
         type: 'string'
         default: terminal.defaultShell()
-        description: 'The location of an executable shell. Set to `$SHELL` by default, and if `$SHELL` isn\'t set then fallback to `bash` or `powershell.exe` (on Windows).'
+        description: 'The location of an executable shell. Set to `$SHELL` by default,
+                      and if `$SHELL` isn\'t set then fallback to `bash` or `powershell.exe` (on Windows).'
         order: 4
       terminal:
         title: 'Terminal'
@@ -461,7 +462,8 @@ config =
     order: 99
 
 if process.platform != 'darwin'
-  config.consoleOptions.properties.whitelistedKeybindingsREPL.default = ['Ctrl-C', 'Ctrl-J', 'Ctrl-K', 'Ctrl-E', 'Ctrl-V', 'Ctrl-M']
+  config.consoleOptions.properties.whitelistedKeybindingsREPL.default =
+    ['Ctrl-C', 'Ctrl-J', 'Ctrl-K', 'Ctrl-E', 'Ctrl-V', 'Ctrl-M']
 
 if process.platform == 'darwin'
   config.consoleOptions.properties.macOptionIsMeta =

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -156,8 +156,8 @@ config =
         type: 'boolean'
         default: false
         order: 10
-      customLayoutOptions:
-        title: 'Custom Layout Options'
+      layouts:
+        title: 'Layout'
         type: 'object'
         order: 11
         collapsed: true

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -33,7 +33,7 @@ config =
       deprecationWarnings:
         title: 'Deprecation Warnings'
         type: 'boolean'
-        description: 'Hides deprecation warnings if disabled.'
+        description: 'If disabled, hides deprecation warnings.'
         default: true
         order: 3
       numberOfThreads:
@@ -54,7 +54,7 @@ config =
           type: 'string'
         order: 5
       externalProcessPort:
-        title: 'Port for communicating with the Julia process'
+        title: 'Port for Communicating with the Julia Process'
         type: 'string'
         description: '`random` will use a new port each time, or enter an integer to set the port statically.'
         default: 'random'
@@ -137,29 +137,29 @@ config =
         type: 'boolean'
         description: 'Show plots in Atom.'
         default: true
-        order: 6.5
+        order: 7
       openNewEditorWhenDebugging:
         title: 'Open New Editor When Debugging'
         type: 'boolean'
         default: false
         description: 'Opens a new editor tab when stepping into a new file instead
                       of reusing the current one (requires restart).'
-        order: 7
+        order: 8
       cellDelimiter:
         title: 'Cell Delimiter'
         type: 'array'
         default: ['##', '#---', '#%%', '# %%']
         description: 'Regular expressions for determining cell delimiters.'
-        order: 8
+        order: 9
       useStandardLayout:
         title: 'Restore Standard Layout on Start'
         type: 'boolean'
         default: false
-        order: 9
+        order: 10
       customLayoutOptions:
         title: 'Custom Layout Options'
         type: 'object'
-        order: 10
+        order: 11
         collapsed: true
         properties:
           console:
@@ -346,7 +346,7 @@ config =
         title: 'Shell'
         type: 'string'
         default: terminal.defaultShell()
-        description: 'Shell. Defaults to `$SHELL`.'
+        description: 'The location of an executable shell. Set to `$SHELL` by default, and if `$SHELL` isn\'t set then fallback to `bash` or `powershell.exe` (on Windows).'
         order: 4
       terminal:
         title: 'Terminal'
@@ -371,6 +371,7 @@ config =
         type: 'string'
         enum: ['block', 'underline', 'bar']
         default: 'block'
+        radio: true
         order: 8
       cursorBlink:
         title: 'Cursor Blink'
@@ -405,7 +406,7 @@ config =
         order: 3
       agentAuth:
         title: 'Use SSH agent'
-        description: 'Requires `$SSH_AUTH_SOCKET` to be set. Defaults to putty\'s pageant on Windows'
+        description: 'Requires `$SSH_AUTH_SOCKET` to be set. Defaults to putty\'s pageant on Windows.'
         type: 'boolean'
         default: true
         order: 4
@@ -431,7 +432,7 @@ if process.platform == 'darwin'
     order: 5.5
 
 if process.platform == 'win32'
-  config.juliaOptions.enablePowershellWrapper =
+  config.juliaOptions.properties.enablePowershellWrapper =
     title: 'Enable Powershell Wrapper'
     type: 'boolean'
     default: true

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -77,6 +77,12 @@ config =
         type: 'string'
         default: ''
         order: 9
+      noAutoParenthesis:
+        title: 'Don\'t Insert Parenthesis on Function Autocompletion'
+        description: 'If enabled, Juno will not insert parenthesis after completing a function.'
+        type: 'boolean'
+        default: false
+        order: 10
   uiOptions:
     title: 'UI Options'
     type: 'object'
@@ -316,12 +322,6 @@ config =
                 default: 'no split'
                 radio: true
                 order: 2
-      noAutoParenthesis:
-        title: 'Don\'t Insert Parenthesis on Function Autocompletion'
-        description: 'Juno will not insert parenthesis after completing a function if this is enabled.'
-        type: 'boolean'
-        default: false
-        order: 11
   consoleOptions:
     type: 'object'
     order: 4
@@ -431,12 +431,11 @@ if process.platform == 'darwin'
     order: 5.5
 
 if process.platform == 'win32'
-  config.enablePowershellWrapper =
+  config.juliaOptions.enablePowershellWrapper =
     title: 'Enable Powershell Wrapper'
     type: 'boolean'
     default: true
-    description: 'Use a powershell wrapper to spawn Julia.
-                  Necessary to enable interrupts.'
-    order: 2.5
+    description: 'If enabled, use a Powershell wrapper to spawn Julia. Necessary to enable interrupts.'
+    order: 11
 
 module.exports = config

--- a/lib/package/settings.js
+++ b/lib/package/settings.js
@@ -16,7 +16,7 @@ export function updateSettings() {
   const currentConfig = atom.config.get('julia-client')
   searchForDeprecated(currentConfig, [])
 
-  if (invalidSchemes) {
+  if (invalidSchemes.length > 0) {
     const message = atom.notifications.addWarning('Julia-Client: Invalid (deprecated) settings found', {
       detail: invalidSchemes.join('\n'),
       dismissable: true,

--- a/lib/package/settings.js
+++ b/lib/package/settings.js
@@ -1,18 +1,91 @@
 'use babel'
-// update top-level settings from pre-0.6.10
 
-export function updateSettings () {
-  let config = require('../package/config')
-  let currentSettings = atom.config.get('julia-client')
+let validSchemes = require('../package/config')
+let invalidSchemes = []  // Keeps invalid config schemes to be notified to users
 
-  let val
-  for (let key in currentSettings) {
-    // old setting
-    if (config[key] == undefined) {
-      // JuliaPro specific:
-      if (key == 'useStandardLayout') continue
-      // unset, so no-one tries to change this
-      atom.config.unset('julia-client.' + key)
-    }
+function dispose() {
+  validSchemes = null
+  invalidSchemes = null
+}
+
+/**
+ * Updates settings by removing deprecated (i.e.: not used anymore) configs so that no one tries to
+ * tweak them.
+ */
+export function updateSettings() {
+  const currentConfig = atom.config.get('julia-client')
+  searchForDeprecated(currentConfig, [])
+
+  if (invalidSchemes) {
+    const message = atom.notifications.addWarning('Julia-Client: Invalid (deprecated) settings found', {
+      detail: invalidSchemes.join('\n'),
+      dismissable: true,
+      description: 'Remove these invalid settings ?',
+      buttons: [
+        {
+          text: 'Yes',
+          onDidClick: () => {
+            message.dismiss()
+            invalidSchemes.forEach((invalidScheme) => {
+              atom.config.unset(invalidScheme)
+            })
+            dispose()
+          }
+        },
+        {
+          text: 'Yes, and check the settings',
+          onDidClick: () => {
+            message.dismiss()
+            invalidSchemes.forEach((invalidScheme) => {
+              atom.config.unset(invalidScheme)
+            })
+            atom.workspace.open('atom://config/packages/julia-client')
+            dispose()
+          }
+        },
+        {
+          text: 'No',
+          onDidClick: () => {
+            message.dismiss()
+            dispose()
+          }
+        }
+      ]
+    })
   }
+}
+
+/**
+ * Recursively search deprecated configs
+ */
+function searchForDeprecated(config, currentSchemes) {
+  Object.entries(config).forEach(([key, value]) => {
+    // NOTE: Traverse the current config by post-order in order to push all the invalid config
+    // schemes into `invalidSchemes`
+    if (Object.prototype.toString.call(value) === '[object Object]') {
+      const nextSchemes = currentSchemes.slice(0)
+      nextSchemes.push(key)
+      searchForDeprecated(value, nextSchemes)
+    }
+
+    // Search for a valid scheme corresponding to invalid one
+    let validScheme = validSchemes
+    currentSchemes.forEach((scheme) => {
+      Object.entries(validScheme).forEach(([_key, _value]) => {
+        if (_key === scheme) {
+          validScheme = _value
+        } else if (_key === 'properties' && _value[scheme]) {
+          validScheme = _value[scheme]
+        }
+      })
+    });
+
+    // If the valid scheme doesn't have the current config scheme, push it to `invalidSchemes`
+    if (!validScheme[key] && (!validScheme.properties || !validScheme.properties[key])) {
+      let invalidScheme = 'julia-client.'
+      invalidScheme += currentSchemes.length === 0 ? '' : `${currentSchemes.join('.')}.`
+      invalidScheme += key
+      invalidSchemes.push(invalidScheme)
+    }
+  });
 }

--- a/lib/package/settings.js
+++ b/lib/package/settings.js
@@ -33,17 +33,6 @@ export function updateSettings() {
           }
         },
         {
-          text: 'Yes, and check the settings',
-          onDidClick: () => {
-            message.dismiss()
-            invalidSchemes.forEach((invalidScheme) => {
-              atom.config.unset(invalidScheme)
-            })
-            atom.workspace.open('atom://config/packages/julia-client')
-            dispose()
-          }
-        },
-        {
           text: 'No',
           onDidClick: () => {
             message.dismiss()

--- a/lib/package/settings.js
+++ b/lib/package/settings.js
@@ -49,15 +49,15 @@ export function updateSettings() {
  */
 function searchForDeprecated(config, currentSchemes) {
   Object.entries(config).forEach(([key, value]) => {
-    // NOTE: Traverse the current config by post-order in order to push all the invalid config
-    // schemes into `invalidSchemes`
+    // @NOTE: Traverse the current config schemes by post-order in order to push all the invalid
+    // config schemes into `invalidSchemes`
     if (Object.prototype.toString.call(value) === '[object Object]') {
       const nextSchemes = currentSchemes.slice(0)
       nextSchemes.push(key)
       searchForDeprecated(value, nextSchemes)
     }
 
-    // Search for a valid scheme corresponding to invalid one
+    // Make `validScheme` corresponding to `currentSchemes` path for the validity checking below
     let validScheme = validSchemes
     currentSchemes.forEach((scheme) => {
       Object.entries(validScheme).forEach(([_key, _value]) => {
@@ -69,7 +69,7 @@ function searchForDeprecated(config, currentSchemes) {
       })
     });
 
-    // If the valid scheme doesn't have the current config scheme, push it to `invalidSchemes`
+    // Check if the `config` scheme being searched at this recursion is in `validScheme`
     if (!validScheme[key] && (!validScheme.properties || !validScheme.properties[key])) {
       let invalidScheme = 'julia-client.'
       invalidScheme += currentSchemes.length === 0 ? '' : `${currentSchemes.join('.')}.`

--- a/lib/runtime/completions.coffee
+++ b/lib/runtime/completions.coffee
@@ -63,7 +63,7 @@ module.exports =
     Promise.race([cs, @sleep(1)])
 
   onDidInsertSuggestion: ({editor, suggestion: {type}}) ->
-    if type is 'function' and !atom.config.get('julia-client.uiOptions.noAutoParenthesis')
+    if type is 'function' and !atom.config.get('julia-client.juliaOptions.noAutoParenthesis')
       editor.mutateSelectedText (selection) ->
         return unless selection.isEmpty()
         {row, column} = selection.getBufferRange().start

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -150,7 +150,7 @@ export function activate (_ink) {
 }
 
 function newTerminal () {
-  let term = ink.InkTerminal.fromId(`terminal-julia-${Math.floor(Math.random()*10000000)}`, terminalOptions())
+  const term = ink.InkTerminal.fromId(`terminal-julia-${Math.floor(Math.random()*10000000)}`, terminalOptions())
   term.attachCustomKeyEventHandler(handleWhitelistedKeybindingTerminal)
   addLinkHandler(term.terminal)
   shellPty().then(({pty, cwd}) => {
@@ -163,7 +163,7 @@ function newTerminal () {
 }
 
 function newRemoteTerminal () {
-  let term = ink.InkTerminal.fromId(`terminal-remote-julia-${Math.floor(Math.random()*10000000)}`, terminalOptions())
+  const term = ink.InkTerminal.fromId(`terminal-remote-julia-${Math.floor(Math.random()*10000000)}`, terminalOptions())
   term.attachCustomKeyEventHandler(handleWhitelistedKeybindingTerminal)
   addLinkHandler(term.terminal)
   remotePty().then(({pty, cwd, conf}) => {
@@ -178,7 +178,7 @@ function newRemoteTerminal () {
 }
 
 function terminalOptions () {
-  let opts = {
+  const opts = {
     scrollback: atom.config.get('julia-client.consoleOptions.maximumConsoleSize'),
     cursorStyle: atom.config.get('julia-client.consoleOptions.cursorStyle'),
     rendererType: atom.config.get('julia-client.consoleOptions.rendererType') ? 'dom' : 'canvas',
@@ -193,7 +193,7 @@ function terminalOptions () {
 function updateTerminalSettings () {
   const settings = terminalOptions()
   forEachPane((item) => {
-    for (key in settings) {
+    for (const key in settings) {
       if (key === 'rendererType') {
         if (!item.element.initialized) continue
       }
@@ -234,7 +234,7 @@ function handleLink (event, uri) {
     } else {
       urimatch = uri.match(/([^\:]+)(?:\:(\d+))?/)
       if (urimatch) {
-        line = urimatch[2] !== null ? parseInt(urimatch[2]) : 0
+        const line = urimatch[2] !== null ? parseInt(urimatch[2]) : 0
         ink.Opener.open(urimatch[1], line - 1, {pending: true})
       }
     }
@@ -255,7 +255,7 @@ function handleWhitelistedKeybindingTerminal (e) {
 function remotePty () {
   return withRemoteConfig(conf => {
     return new Promise((resolve, reject) => {
-      let conn = new ssh.Client()
+      const conn = new ssh.Client()
       conn.on('ready', () => {
         conn.shell({ term: "xterm-256color" }, (err, stream) => {
           if (err) console.error(`Error while starting remote shell.`)
@@ -280,7 +280,7 @@ function shellPty (cwd) {
     if (cwd) {
       pr = new Promise((resolve) => resolve(cwd))
     } else {
-      let projectPaths = atom.workspace.project.getDirectories().map((el) => el.path)
+      const projectPaths = atom.workspace.project.getDirectories().map((el) => el.path)
       pr = selector.show(projectPaths, {
         emptyMessage: 'Enter a custom path above.',
         allowCustom: true

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -27,13 +27,15 @@ var ink = undefined
 
 export var terminal
 
+let subs
+
 export function activate (_ink) {
   if (atom.config.get('julia-client.consoleOptions.consoleStyle') != 'REPL-based') return
   ink = _ink
 
   process.env.TERM = 'xterm-256color'
 
-  let subs = new CompositeDisposable()
+  subs = new CompositeDisposable()
 
   subs.add(atom.config.observe('julia-client.consoleOptions.whitelistedKeybindingsREPL', (kbds) => {
     whitelistedKeybindingsREPL = kbds.map(s => s.toLowerCase())
@@ -51,6 +53,10 @@ export function activate (_ink) {
 
   terminal.setTitle('REPL', true)
   terminal.class = 'julia-terminal'
+
+  subs.add(atom.config.observe('julia-client.uiOptions.customLayoutOptions.console.defaultLocation', (defaultLocation) => {
+    terminal.setDefaultLocation(defaultLocation)
+  }))
 
   terminal.write('\x1b[1m\x1b[32mPress Enter to start Julia. \x1b[0m\n\r')
   terminal.startRequested = () => {
@@ -111,7 +117,9 @@ export function activate (_ink) {
   })
 
   subs.add(atom.commands.add('atom-workspace', 'julia-client:open-console', () => {
-    terminal.open().then(() => terminal.show())
+    terminal.open({
+      split: atom.config.get('julia-client.uiOptions.customLayoutOptions.console.split')
+    }).then(() => terminal.show())
   }))
 
   subs.add(atom.commands.add('atom-workspace', 'julia-client:clear-console', () => {
@@ -147,7 +155,10 @@ function newTerminal () {
   addLinkHandler(term.terminal)
   shellPty().then(({pty, cwd}) => {
     term.attach(pty, true, cwd)
-    term.open().then(() => term.show())
+    term.setDefaultLocation(atom.config.get('julia-client.uiOptions.customLayoutOptions.terminal.defaultLocation'))
+    term.open({
+      split: atom.config.get('julia-client.uiOptions.customLayoutOptions.terminal.split')
+    }).then(() => term.show())
   }).catch(() => {})
 }
 
@@ -158,7 +169,10 @@ function newRemoteTerminal () {
   remotePty().then(({pty, cwd, conf}) => {
     term.attach(pty, true, cwd)
     term.setTitle(`Terminal @ ${conf.name}`)
-    term.open().then(() => term.show())
+    term.setDefaultLocation(atom.config.get('julia-client.uiOptions.customLayoutOptions.terminal.defaultLocation'))
+    term.open({
+      split: atom.config.get('julia-client.uiOptions.customLayoutOptions.terminal.split')
+    }).then(() => term.show())
     pty.on('close', () => term.detach())
   }).catch((e) => console.error(e))
 }
@@ -305,5 +319,8 @@ export function deactivate () {
   }, /terminal\-remote\-julia\-\d+/)
   terminal.detach()
 
-  if (subs) subs.dispose()
+  if (subs) {
+    subs.dispose()
+    subs = null
+  }
 }

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -54,7 +54,7 @@ export function activate (_ink) {
   terminal.setTitle('REPL', true)
   terminal.class = 'julia-terminal'
 
-  subs.add(atom.config.observe('julia-client.uiOptions.customLayoutOptions.console.defaultLocation', (defaultLocation) => {
+  subs.add(atom.config.observe('julia-client.uiOptions.layouts.console.defaultLocation', (defaultLocation) => {
     terminal.setDefaultLocation(defaultLocation)
   }))
 
@@ -118,7 +118,7 @@ export function activate (_ink) {
 
   subs.add(atom.commands.add('atom-workspace', 'julia-client:open-console', () => {
     terminal.open({
-      split: atom.config.get('julia-client.uiOptions.customLayoutOptions.console.split')
+      split: atom.config.get('julia-client.uiOptions.layouts.console.split')
     }).then(() => terminal.show())
   }))
 
@@ -155,9 +155,9 @@ function newTerminal () {
   addLinkHandler(term.terminal)
   shellPty().then(({pty, cwd}) => {
     term.attach(pty, true, cwd)
-    term.setDefaultLocation(atom.config.get('julia-client.uiOptions.customLayoutOptions.terminal.defaultLocation'))
+    term.setDefaultLocation(atom.config.get('julia-client.uiOptions.layouts.terminal.defaultLocation'))
     term.open({
-      split: atom.config.get('julia-client.uiOptions.customLayoutOptions.terminal.split')
+      split: atom.config.get('julia-client.uiOptions.layouts.terminal.split')
     }).then(() => term.show())
   }).catch(() => {})
 }
@@ -169,9 +169,9 @@ function newRemoteTerminal () {
   remotePty().then(({pty, cwd, conf}) => {
     term.attach(pty, true, cwd)
     term.setTitle(`Terminal @ ${conf.name}`)
-    term.setDefaultLocation(atom.config.get('julia-client.uiOptions.customLayoutOptions.terminal.defaultLocation'))
+    term.setDefaultLocation(atom.config.get('julia-client.uiOptions.layouts.terminal.defaultLocation'))
     term.open({
-      split: atom.config.get('julia-client.uiOptions.customLayoutOptions.terminal.split')
+      split: atom.config.get('julia-client.uiOptions.layouts.terminal.split')
     }).then(() => term.show())
     pty.on('close', () => term.detach())
   }).catch((e) => console.error(e))

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -24,18 +24,15 @@ if (process.platform === 'win32') {
 var whitelistedKeybindingsREPL = []
 var whitelistedKeybindingsTerminal = []
 var ink = undefined
+let subs = new CompositeDisposable()
 
 export var terminal
-
-let subs
 
 export function activate (_ink) {
   if (atom.config.get('julia-client.consoleOptions.consoleStyle') != 'REPL-based') return
   ink = _ink
 
   process.env.TERM = 'xterm-256color'
-
-  subs = new CompositeDisposable()
 
   subs.add(atom.config.observe('julia-client.consoleOptions.whitelistedKeybindingsREPL', (kbds) => {
     whitelistedKeybindingsREPL = kbds.map(s => s.toLowerCase())
@@ -117,9 +114,7 @@ export function activate (_ink) {
   })
 
   subs.add(atom.commands.add('atom-workspace', 'julia-client:open-console', () => {
-    terminal.open({
-      split: atom.config.get('julia-client.uiOptions.layouts.console.split')
-    }).then(() => terminal.show())
+    open().then(() => terminal.show())
   }))
 
   subs.add(atom.commands.add('atom-workspace', 'julia-client:clear-console', () => {
@@ -147,6 +142,12 @@ export function activate (_ink) {
     }
   }, /terminal\-julia\-\d+/)
   forEachPane(item => item.close(), /terminal\-remote\-julia\-\d+/)
+}
+
+export function open () {
+  return terminal.open({
+    split: atom.config.get('julia-client.uiOptions.layouts.console.split')
+  })
 }
 
 function newTerminal () {
@@ -319,8 +320,6 @@ export function deactivate () {
   }, /terminal\-remote\-julia\-\d+/)
   terminal.detach()
 
-  if (subs) {
-    subs.dispose()
-    subs = null
-  }
+  subs.dispose()
+  subs = null
 }

--- a/lib/runtime/console2.js
+++ b/lib/runtime/console2.js
@@ -150,6 +150,10 @@ export function open () {
   })
 }
 
+export function close () {
+  return terminal.close()
+}
+
 function newTerminal () {
   const term = ink.InkTerminal.fromId(`terminal-julia-${Math.floor(Math.random()*10000000)}`, terminalOptions())
   term.attachCustomKeyEventHandler(handleWhitelistedKeybindingTerminal)

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -57,8 +57,8 @@ export function deactivate() {
   subs.dispose()
 }
 
-export function openPane () {
-  debuggerPane.open({
+export function open () {
+  return debuggerPane.open({
     split: atom.config.get('julia-client.uiOptions.layouts.debuggerPane.split')
   })
 }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -63,6 +63,10 @@ export function open () {
   })
 }
 
+export function close () {
+  return debuggerPane.close()
+}
+
 function activeError() {
   if (!active) {
     atom.notifications.addError('You need to be debugging to do that.', {

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -14,6 +14,7 @@ let {addsourcebp, removesourcebp, getbps} =
 let active, stepper, subs, breakpoints, debuggerPane
 
 export function activate (ink) {
+  const buttons = [
     {icon: 'playback-fast-forward', tooltip: 'Debug: Continue', command: 'julia-debug:continue'},
     {icon: 'link-external', tooltip: 'Debug: Finish Function', command: 'julia-debug:finish-function'},
     {icon: 'arrow-down', tooltip: 'Debug: Next Line', command: 'julia-debug:step-to-next-line'},
@@ -94,7 +95,7 @@ client.handle({
   working() { client.ipc.loading.working() },
   doneWorking() { client.ipc.loading.done() },
   getFileBreakpoints() {
-    let bps = breakpoints.getFileBreakpoints()
+    const bps = breakpoints.getFileBreakpoints()
     return bps.filter(bp => bp.isactive).map(bp => {
       return {
         file: bp.file,
@@ -113,7 +114,7 @@ export function stop()     { requireDebugging(() => client.import('stop')()) }
 export function continueForward() { requireDebugging(() => client.import('continue')()) }
 export function toselectedline() {
   requireDebugging(() => {
-    let ed = stepper.edForFile(stepper.file)
+    const ed = stepper.edForFile(stepper.file)
     if (ed != null) {
       client.import('toline')(ed.getCursorBufferPosition().row + 1)
     }
@@ -121,7 +122,7 @@ export function toselectedline() {
 }
 
 function bufferForFile(file) {
-  for (let ed of atom.workspace.getTextEditors()) {
+  for (const ed of atom.workspace.getTextEditors()) {
     if (ed.getBuffer().getPath() === file)
       return ed.getBuffer()
   }

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -11,12 +11,9 @@ import workspace from './workspace'
 let {addsourcebp, removesourcebp, getbps} =
   client.import(['addsourcebp', 'removesourcebp', 'getbps'])
 
-let ink, active, stepper, subs, breakpoints, debuggerPane
+let active, stepper, subs, breakpoints, debuggerPane
 
-export function activate (i) {
-  ink = i
-
-  let buttons = [
+export function activate (ink) {
     {icon: 'playback-fast-forward', tooltip: 'Debug: Continue', command: 'julia-debug:continue'},
     {icon: 'link-external', tooltip: 'Debug: Finish Function', command: 'julia-debug:finish-function'},
     {icon: 'arrow-down', tooltip: 'Debug: Next Line', command: 'julia-debug:step-to-next-line'},
@@ -45,7 +42,9 @@ export function activate (i) {
   debuggerPane = ink.DebuggerPane.fromId('julia-debugger-pane', stepper, breakpoints, buttons)
 
   subs = new CompositeDisposable()
-
+  subs.add(atom.config.observe('julia-client.uiOptions.customLayoutOptions.debuggerPane.defaultLocation', (defaultLocation) => {
+    debuggerPane.setDefaultLocation(defaultLocation)
+  }))
   subs.add(client.onDetached(() => {
     debugmode(false)
     breakpoints.clear(true)
@@ -58,7 +57,9 @@ export function deactivate() {
 }
 
 export function openPane () {
-  debuggerPane.open()
+  debuggerPane.open({
+    split: atom.config.get('julia-client.uiOptions.customLayoutOptions.debuggerPane.split')
+  })
 }
 
 function activeError() {

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -43,7 +43,7 @@ export function activate (ink) {
   debuggerPane = ink.DebuggerPane.fromId('julia-debugger-pane', stepper, breakpoints, buttons)
 
   subs = new CompositeDisposable()
-  subs.add(atom.config.observe('julia-client.uiOptions.customLayoutOptions.debuggerPane.defaultLocation', (defaultLocation) => {
+  subs.add(atom.config.observe('julia-client.uiOptions.layouts.debuggerPane.defaultLocation', (defaultLocation) => {
     debuggerPane.setDefaultLocation(defaultLocation)
   }))
   subs.add(client.onDetached(() => {
@@ -59,7 +59,7 @@ export function deactivate() {
 
 export function openPane () {
   debuggerPane.open({
-    split: atom.config.get('julia-client.uiOptions.customLayoutOptions.debuggerPane.split')
+    split: atom.config.get('julia-client.uiOptions.layouts.debuggerPane.split')
   })
 }
 

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -111,8 +111,8 @@ module.exports =
           highlight: true
         d.view.classList.add 'julia'
       else
-        docpane.pane.ensureVisible()
-        docpane.pane.showDocument(v, [])
+        docpane.ensureVisible()
+        docpane.showDocument(v, [])
 
   showError: (r, lines) ->
     @errorLines?.lights.destroy()

--- a/lib/runtime/linter.js
+++ b/lib/runtime/linter.js
@@ -3,31 +3,35 @@
 import { CompositeDisposable } from 'atom'
 import { client } from '../connection'
 
-let subs, linter, ink
+let subs
 
-export function activate (i) {
-  ink = i
-  subs = new CompositeDisposable()
-
-  linter = ink.Linter
+export function activate (ink) {
+  const linter = ink.Linter
 
   client.handle({
     staticLint: (warnings) => {
-      linter.lintPane.ensureVisible()
+      linter.lintPane.ensureVisible({
+        split: atom.config.get('julia-client.uiOptions.customLayoutOptions.linter.split')
+      })
       linter.setItems(warnings)
     },
     clearLint: () => {
       linter.clearItems()
     },
     showCompiled: (name, ...args) => {
-      let cp = linter.CompiledPane.fromId(name)
+      const cp = linter.CompiledPane.fromId(name)
       cp.open({split: 'right'})
       cp.showCode(name, ...args)
     }
   })
 
+  subs = new CompositeDisposable()
+
   subs.add(atom.commands.add('.workspace', {
     'julia-client:clear-linter': () => linter.clearItems()
+  }))
+  subs.add(atom.config.observe('julia-client.uiOptions.customLayoutOptions.linter.defaultLocation', (defaultLocation) => {
+    linter.lintPane.setDefaultLocation(defaultLocation)
   }))
 }
 

--- a/lib/runtime/linter.js
+++ b/lib/runtime/linter.js
@@ -11,7 +11,7 @@ export function activate (ink) {
   client.handle({
     staticLint: (warnings) => {
       linter.lintPane.ensureVisible({
-        split: atom.config.get('julia-client.uiOptions.customLayoutOptions.linter.split')
+        split: atom.config.get('julia-client.uiOptions.layouts.linter.split')
       })
       linter.setItems(warnings)
     },
@@ -30,7 +30,7 @@ export function activate (ink) {
   subs.add(atom.commands.add('.workspace', {
     'julia-client:clear-linter': () => linter.clearItems()
   }))
-  subs.add(atom.config.observe('julia-client.uiOptions.customLayoutOptions.linter.defaultLocation', (defaultLocation) => {
+  subs.add(atom.config.observe('julia-client.uiOptions.layouts.linter.defaultLocation', (defaultLocation) => {
     linter.lintPane.setDefaultLocation(defaultLocation)
   }))
 }

--- a/lib/runtime/linter.js
+++ b/lib/runtime/linter.js
@@ -4,13 +4,15 @@ import { CompositeDisposable } from 'atom'
 import { client } from '../connection'
 
 let subs
+export let lintPane
 
 export function activate (ink) {
   const linter = ink.Linter
+  lintPane = linter.lintPane
 
   client.handle({
     staticLint: (warnings) => {
-      linter.lintPane.ensureVisible({
+      lintPane.ensureVisible({
         split: atom.config.get('julia-client.uiOptions.layouts.linter.split')
       })
       linter.setItems(warnings)
@@ -31,7 +33,7 @@ export function activate (ink) {
     'julia-client:clear-linter': () => linter.clearItems()
   }))
   subs.add(atom.config.observe('julia-client.uiOptions.layouts.linter.defaultLocation', (defaultLocation) => {
-    linter.lintPane.setDefaultLocation(defaultLocation)
+    lintPane.setDefaultLocation(defaultLocation)
   }))
 }
 

--- a/lib/runtime/linter.js
+++ b/lib/runtime/linter.js
@@ -3,8 +3,7 @@
 import { CompositeDisposable } from 'atom'
 import { client } from '../connection'
 
-let subs
-export let lintPane
+let subs, lintPane
 
 export function activate (ink) {
   const linter = ink.Linter
@@ -35,6 +34,12 @@ export function activate (ink) {
   subs.add(atom.config.observe('julia-client.uiOptions.layouts.linter.defaultLocation', (defaultLocation) => {
     lintPane.setDefaultLocation(defaultLocation)
   }))
+}
+
+export function open () {
+  return lintPane.open({
+    split: atom.config.get('julia-client.uiOptions.layouts.linter.split')
+  })
 }
 
 export function deactivate () {

--- a/lib/runtime/linter.js
+++ b/lib/runtime/linter.js
@@ -42,6 +42,10 @@ export function open () {
   })
 }
 
+export function close () {
+  return lintPane.close()
+}
+
 export function deactivate () {
   subs.dispose()
 }

--- a/lib/runtime/plots.coffee
+++ b/lib/runtime/plots.coffee
@@ -27,7 +27,7 @@ module.exports =
       else
         @pane.setTitle 'Plots (disabled)'
 
-    atom.config.observe 'julia-client.uiOptions.customLayoutOptions.plotPane.defaultLocation', (defaultLocation) =>
+    atom.config.observe 'julia-client.uiOptions.layouts.plotPane.defaultLocation', (defaultLocation) =>
       @pane.setDefaultLocation defaultLocation
 
   create: ->
@@ -35,10 +35,10 @@ module.exports =
 
   open: ->
     @pane.open
-      split: atom.config.get('julia-client.uiOptions.customLayoutOptions.plotPane.split')
+      split: atom.config.get('julia-client.uiOptions.layouts.plotPane.split')
 
   ensureVisible: ->
-    @pane.ensureVisible({ split: atom.config.get('julia-client.uiOptions.customLayoutOptions.plotPane.split') })
+    @pane.ensureVisible({ split: atom.config.get('julia-client.uiOptions.layouts.plotPane.split') })
 
   show: (view) ->
     @ensureVisible()

--- a/lib/runtime/plots.coffee
+++ b/lib/runtime/plots.coffee
@@ -86,5 +86,5 @@ module.exports =
         })
 
       pane.ensureVisible({
-        split: opts.split || 'right'
+        split: opts.split || atom.config.get('julia-client.uiOptions.layouts.plotPane.split')
         })

--- a/lib/runtime/plots.coffee
+++ b/lib/runtime/plots.coffee
@@ -40,6 +40,9 @@ module.exports =
   ensureVisible: ->
     @pane.ensureVisible({ split: atom.config.get('julia-client.uiOptions.layouts.plotPane.split') })
 
+  close: ->
+    @pane.close()
+
   show: (view) ->
     @ensureVisible()
     v = views.render view

--- a/lib/runtime/plots.coffee
+++ b/lib/runtime/plots.coffee
@@ -27,14 +27,18 @@ module.exports =
       else
         @pane.setTitle 'Plots (disabled)'
 
+    atom.config.observe 'julia-client.uiOptions.customLayoutOptions.plotPane.defaultLocation', (defaultLocation) =>
+      @pane.setDefaultLocation defaultLocation
+
   create: ->
     @pane = @ink.PlotPane.fromId 'default'
 
   open: ->
-    @pane.open split: 'right'
+    @pane.open
+      split: atom.config.get('julia-client.uiOptions.customLayoutOptions.plotPane.split')
 
   ensureVisible: ->
-    @pane.ensureVisible({split: 'right'})
+    @pane.ensureVisible({ split: atom.config.get('julia-client.uiOptions.customLayoutOptions.plotPane.split') })
 
   show: (view) ->
     @ensureVisible()

--- a/lib/runtime/profiler.js
+++ b/lib/runtime/profiler.js
@@ -43,10 +43,6 @@ function clear () {
   pane.teardown()
 }
 
-function close () {
-  pane.close()
-}
-
 export function deactivate () {
   subs.dispose()
 }

--- a/lib/runtime/profiler.js
+++ b/lib/runtime/profiler.js
@@ -19,8 +19,8 @@ export function activate (ink) {
 
   client.handle({
     profile(data) {
-      let save = (path) => saveProfileTrace(path, data)
-      profile = new ink.Profiler.ProfileViewer({data, save})
+      const save = (path) => saveProfileTrace(path, data)
+      const profile = new ink.Profiler.ProfileViewer({data, save})
       pane.ensureVisible({
         split: 'julia-client.uiOptions.customLayoutOptions.profiler.split'
       })
@@ -34,7 +34,7 @@ export function activate (ink) {
   }))
 
   subs.add(atom.commands.add('atom-workspace', 'julia-client:load-profile-trace', () => {
-    path = remote.dialog.showOpenDialog({title: 'Load Profile Trace', properties: ['openFile']})
+    const path = remote.dialog.showOpenDialog({title: 'Load Profile Trace', properties: ['openFile']})
     loadProfileTrace(path)
   }))
 }

--- a/lib/runtime/profiler.js
+++ b/lib/runtime/profiler.js
@@ -13,7 +13,7 @@ export function activate (ink) {
   subs = new CompositeDisposable()
 
   subs.add(client.onDetached(() => clear()))
-  subs.add(atom.config.observe('julia-client.uiOptions.customLayoutOptions.profiler.defaultLocation', (defaultLocation) => {
+  subs.add(atom.config.observe('julia-client.uiOptions.layouts.profiler.defaultLocation', (defaultLocation) => {
     pane.getDefaultLocation = () => { return defaultLocation }
   }))
 
@@ -22,7 +22,7 @@ export function activate (ink) {
       const save = (path) => saveProfileTrace(path, data)
       const profile = new ink.Profiler.ProfileViewer({data, save})
       pane.ensureVisible({
-        split: 'julia-client.uiOptions.customLayoutOptions.profiler.split'
+        split: 'julia-client.uiOptions.layouts.profiler.split'
       })
       pane.show(new ink.Pannable(profile, {zoomstrategy: 'width', minScale: 0.5}))
     }

--- a/lib/runtime/profiler.js
+++ b/lib/runtime/profiler.js
@@ -9,16 +9,21 @@ var {loadProfileTrace, saveProfileTrace} = client.import({msg: ['loadProfileTrac
 
 export function activate (ink) {
   pane = ink.PlotPane.fromId('Profile')
-  pane.getTitle = function () {return 'Profiler'}
+  pane.getTitle = () => {return 'Profiler'}
   subs = new CompositeDisposable()
 
   subs.add(client.onDetached(() => clear()))
+  subs.add(atom.config.observe('julia-client.uiOptions.customLayoutOptions.profiler.defaultLocation', (defaultLocation) => {
+    pane.getDefaultLocation = () => { return defaultLocation }
+  }))
 
   client.handle({
     profile(data) {
       let save = (path) => saveProfileTrace(path, data)
       profile = new ink.Profiler.ProfileViewer({data, save})
-      pane.ensureVisible({split: 'right'})
+      pane.ensureVisible({
+        split: 'julia-client.uiOptions.customLayoutOptions.profiler.split'
+      })
       pane.show(new ink.Pannable(profile, {zoomstrategy: 'width', minScale: 0.5}))
     }
   })

--- a/lib/runtime/workspace.coffee
+++ b/lib/runtime/workspace.coffee
@@ -47,3 +47,6 @@ module.exports =
   open: ->
     @ws.open
       split: atom.config.get 'julia-client.uiOptions.layouts.workspace.split'
+
+  close: ->
+    @ws.close()

--- a/lib/runtime/workspace.coffee
+++ b/lib/runtime/workspace.coffee
@@ -15,7 +15,7 @@ module.exports =
       @ws.setItems []
       @lazyTrees = []
 
-    atom.config.observe 'julia-client.uiOptions.customLayoutOptions.workspace.defaultLocation', (defaultLocation) =>
+    atom.config.observe 'julia-client.uiOptions.layouts.workspace.defaultLocation', (defaultLocation) =>
       @ws.setDefaultLocation defaultLocation
 
   lazyTrees: []
@@ -46,4 +46,4 @@ module.exports =
 
   open: ->
     @ws.open
-      split: atom.config.get 'julia-client.uiOptions.customLayoutOptions.workspace.split'
+      split: atom.config.get 'julia-client.uiOptions.layouts.workspace.split'

--- a/lib/runtime/workspace.coffee
+++ b/lib/runtime/workspace.coffee
@@ -15,6 +15,9 @@ module.exports =
       @ws.setItems []
       @lazyTrees = []
 
+    atom.config.observe 'julia-client.uiOptions.customLayoutOptions.workspace.defaultLocation', (defaultLocation) =>
+      @ws.setDefaultLocation defaultLocation
+
   lazyTrees: []
 
   update: ->
@@ -41,4 +44,6 @@ module.exports =
       if m?.then?
         m.then(() => @update())
 
-  open: -> @ws.open split: 'right'
+  open: ->
+    @ws.open
+      split: atom.config.get 'julia-client.uiOptions.customLayoutOptions.workspace.split'

--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -21,6 +21,7 @@ module.exports =
 
   deactivate: ->
     @subs.dispose()
+    @docpane.deactivate()
     @focusutils.deactivate()
     @progress.clear()
 

--- a/lib/ui/docs.js
+++ b/lib/ui/docs.js
@@ -4,7 +4,7 @@ import { client } from '../connection'
 import { CompositeDisposable } from 'atom'
 const views = require('./views')
 
-let { searchdocs, methods, moduleinfo, regenerateCache } =
+const { searchdocs, methods, moduleinfo, regenerateCache } =
       client.import({rpc: ['searchdocs', 'methods', 'moduleinfo'], msg: ['regenerateCache']})
 
 let ink

--- a/lib/ui/docs.js
+++ b/lib/ui/docs.js
@@ -22,7 +22,7 @@ export function activate(_ink) {
     return new Promise((resolve) => {
       searchdocs({query: text, mod, exportedOnly, allPackages, nameOnly}).then((res) => {
         if (!res.error) {
-          for (i = 0; i < res.items.length; i++) {
+          for (let i = 0; i < res.items.length; i += 1) {
             res.items[i].score = res.scores[i]
             res.items[i] = processItem(res.items[i])
           }
@@ -35,13 +35,13 @@ export function activate(_ink) {
   subs = new CompositeDisposable()
   subs.add(atom.commands.add('atom-workspace', 'julia-client:open-documentation-browser', () => {
     pane.open({
-      split: atom.config.get('julia-client.uiOptions.customLayoutOptions.documentation.split')
+      split: atom.config.get('julia-client.uiOptions.layouts.documentation.split')
     })
   }))
   subs.add(atom.commands.add('atom-workspace', 'julia-client:regenerate-doc-cache', () => {
     regenerateCache()
   }))
-  subs.add(atom.config.observe('julia-client.uiOptions.customLayoutOptions.documentation.defaultLocation', (defaultLocation) => {
+  subs.add(atom.config.observe('julia-client.uiOptions.layouts.documentation.defaultLocation', (defaultLocation) => {
     pane.setDefaultLocation(defaultLocation)
   }))
 }

--- a/lib/ui/docs.js
+++ b/lib/ui/docs.js
@@ -7,10 +7,7 @@ const views = require('./views')
 const { searchdocs, methods, moduleinfo, regenerateCache } =
       client.import({rpc: ['searchdocs', 'methods', 'moduleinfo'], msg: ['regenerateCache']})
 
-let ink
-let subs
-
-export var pane
+let ink, subs, pane
 
 export function activate(_ink) {
   ink = _ink
@@ -33,17 +30,24 @@ export function activate(_ink) {
   }
 
   subs = new CompositeDisposable()
-  subs.add(atom.commands.add('atom-workspace', 'julia-client:open-documentation-browser', () => {
-    pane.open({
-      split: atom.config.get('julia-client.uiOptions.layouts.documentation.split')
-    })
-  }))
+  subs.add(atom.commands.add('atom-workspace', 'julia-client:open-documentation-browser', open))
   subs.add(atom.commands.add('atom-workspace', 'julia-client:regenerate-doc-cache', () => {
     regenerateCache()
   }))
   subs.add(atom.config.observe('julia-client.uiOptions.layouts.documentation.defaultLocation', (defaultLocation) => {
     pane.setDefaultLocation(defaultLocation)
   }))
+}
+
+export function open () {
+  return pane.open({
+    split: atom.config.get('julia-client.uiOptions.layouts.documentation.split')
+  })
+}
+export function ensureVisible () {
+  return pane.ensureVisible({
+    split: atom.config.get('julia-client.uiOptions.layouts.documentation.split')
+  })
 }
 
 function processItem (item) {
@@ -59,7 +63,7 @@ function processItem (item) {
   item.onClickModule = () => {
     moduleinfo({mod: item.mod}).then(({doc, items}) => {
       items.map((x) => processItem(x))
-      return pane.showDocument(views.render(doc), items)
+      showDocument(views.render(doc), items)
     })
   }
 
@@ -73,6 +77,10 @@ export function processLinks (links) {
       links[i].onclick = () => pane.kwsearch(link.innerText)
     }
   }
+}
+
+export function showDocument (view, items) {
+  pane.showDocument(view, items)
 }
 
 export function deactivate () {

--- a/lib/ui/docs.js
+++ b/lib/ui/docs.js
@@ -8,6 +8,7 @@ let { searchdocs, methods, moduleinfo, regenerateCache } =
       client.import({rpc: ['searchdocs', 'methods', 'moduleinfo'], msg: ['regenerateCache']})
 
 let ink
+let subs
 
 export var pane
 
@@ -32,13 +33,16 @@ export function activate(_ink) {
   }
 
   subs = new CompositeDisposable()
-
   subs.add(atom.commands.add('atom-workspace', 'julia-client:open-documentation-browser', () => {
-    pane.open()
+    pane.open({
+      split: atom.config.get('julia-client.uiOptions.customLayoutOptions.documentation.split')
+    })
   }))
-
   subs.add(atom.commands.add('atom-workspace', 'julia-client:regenerate-doc-cache', () => {
     regenerateCache()
+  }))
+  subs.add(atom.config.observe('julia-client.uiOptions.customLayoutOptions.documentation.defaultLocation', (defaultLocation) => {
+    pane.setDefaultLocation(defaultLocation)
   }))
 }
 
@@ -69,4 +73,9 @@ export function processLinks (links) {
       links[i].onclick = () => pane.kwsearch(link.innerText)
     }
   }
+}
+
+export function deactivate () {
+  subs.dispose()
+  subs = null
 }

--- a/lib/ui/docs.js
+++ b/lib/ui/docs.js
@@ -49,6 +49,9 @@ export function ensureVisible () {
     split: atom.config.get('julia-client.uiOptions.layouts.documentation.split')
   })
 }
+export function close () {
+  return pane.close()
+}
 
 function processItem (item) {
   item.html = views.render(item.html)

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -1,6 +1,5 @@
 'use babel'
 
-// @NOTE: Sort panes by importance for `openPanesHelper`
 const repl = () => {
   return require('../runtime').console2
 }
@@ -22,6 +21,7 @@ const linter = () => {
 
 function specifiedPanes () {
   const panes = []
+  // @NOTE: Push panes in order of their 'importance': Refer to function `openPanesHelper` for why
   if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.console')) panes.push(repl)
   if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.workspace')) panes.push(workspace)
   if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.documentation')) panes.push(documentation)
@@ -33,7 +33,7 @@ function specifiedPanes () {
 }
 
 function closePromises () {
-  // Close only specified panes, i.e.: non-specified panes won't layouted
+  // Close only specified panes, i.e.: non-specified panes won't be closed/opened
   const panes = specifiedPanes()
 
   const promises = panes.map(pane => {
@@ -71,8 +71,8 @@ function openPanes () {
 
 function openPanesHelper (panes) {
   if (panes.length === 0) {
-    // If there is no more pane to be opened, activate the first item in each pane,
-    // since Juno-panes are ordered so that "earlier-open, more important" above
+    // If there is no more pane to be opened, activate the first item in each pane. This works since
+    // Juno-panes are opened in order of their importance as defined in `specifiedPanes` function
     atom.workspace.getPanes().forEach(pane => {
       pane.activateItemAtIndex(0)
     })
@@ -85,7 +85,7 @@ function openPanesHelper (panes) {
     console.error(err)
     pane().open()
   }).finally(() => {
-    // Re-focust the previously focused pane (simplified pane by `bundlePanes`) after each opening
+    // Re-focus the previously focused pane (i.e. the bundled pane by `bundlePanes`) after each opening
     // This prevents opening multiple panes with the same splitting rule in a same location from
     // ending up in a funny state
     const container = atom.workspace.getActivePaneContainer()

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -80,7 +80,11 @@ function openPanesHelper (panes) {
   }
 
   const pane = panes.shift()
-  pane().open().then(() => {
+  pane().open().catch((err) => {
+    // @FIXME: This is a temporal remedy for https://github.com/JunoLab/atom-julia-client/pull/561#issuecomment-500150318
+    console.error(err)
+    pane().open()
+  }).finally(() => {
     // Re-focust the previously focused pane (simplified pane by `bundlePanes`) after each opening
     // This prevents opening multiple panes with the same splitting rule in a same location from
     // ending up in a funny state

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -1,101 +1,72 @@
 'use babel'
 
-export function queryStandardLayout () {
-  let msg = atom.notifications.addInfo("Use Standard Layout?", {
-    buttons: [{text: "Yes", onDidClick: () => {
-      standard()
-      msg.dismiss()
-      atom.config.set('julia-client.uiOptions.useStandardLayout', true)
-      atom.config.set('julia-client.firstBoot', false)
-    }}, {text: "No", onDidClick: () => {
-      msg.dismiss()
-      atom.config.set('julia-client.uiOptions.useStandardLayout', false)
-      atom.config.set('julia-client.firstBoot', false)
-    }}],
-    description: `Opens various Julia specific panes in a default layout.
-    Use the \`Julia: Standard Layout\` command to reset the layout at later point in time.`,
-    dismissable: true
+const repl = () => {
+  return require('../runtime').console2.terminal.open({
+    split: atom.config.get('julia-client.uiOptions.layouts.console.split')
+  })
+}
+const workspace = () => {
+  return require('../runtime').workspace.open()
+}
+const plotPane = () => {
+  return require('../runtime').plots.open()
+}
+const debuggerPane = () => {
+  return require('../runtime').debugger.openPane()
+}
+const linter = () => {
+  return require('../runtime').linter.linterPane.ensureVisible({
+    split: atom.config.get('julia-client.uiOptions.layouts.linter.split')
+  })
+}
+const documentation = () => {
+  return require('../ui').docpane.pane.open({
+    split: atom.config.get('julia-client.uiOptions.layouts.documentation.split')
   })
 }
 
-function getPanes() {
-  if (atom.workspace.getBottomDock) {
-    return atom.workspace.getPanes().slice(0, -3)
-  } else {
-    return atom.workspace.getPanes()
-  }
+export function defaultLayout () {
+  const activeItem = atom.workspace.getActivePaneItem()
+  const activePane = atom.workspace.getActivePane()
+
+  const panes = []
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.console')) panes.push(repl())
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.workspace')) panes.push(workspace())
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.documentation')) panes.push(documentation())
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.plotPane')) panes.push(plotPane())
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.debuggerPane')) panes.push(debuggerPane())
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.linter')) panes.push(linter())
+
+  Promise.all(panes).then(() => {
+    activePane.focus()
+    activePane.activateItem(activeItem)
+  })
 }
 
-export function isCustomLayout() {
-  return getPanes().length > 1
-}
-
-function resetLayout() {
-  pane = getPanes()[0]
-  for (let p of getPanes().slice(1)) {
-    for (let item of p.getItems()) {
-      p.moveItemToPane(item, pane)
-    }
-  }
-}
-
-function createLayout(layout,
-                      pane = atom.workspace.getActivePane()) {
-  if (!layout){
-  } else if (layout.split && layout.items) {
-    let ps = [pane]
-    ps.push(layout.vertical ? pane.splitDown() : pane.splitRight())
-    for (let i = 0; i < ps.length; i++) {
-      createLayout(layout.items[i], ps[i])
-    }
-  } else if (!layout.split && layout.items) {
-    for (let i = 0; i < layout.items.length; i++) {
-      pane.activateItem(layout.items[i])
-    }
-  } else if (layout instanceof Array) {
-    for (let i = 0; i < layout.length; i++) {
-      pane.activateItem(layout[i])
-    }
-  } else {
-    pane.activateItem(layout)
-  }
-}
-
-function workspace() { return require('../runtime').workspace.ws }
-function docs() { return require('../ui').docpane.pane }
-function cons() {
-  if (atom.config.get('julia-client.consoleOptions.consoleStyle') == 'REPL-based') {
-    return require('../runtime').console2.terminal
-  } else {
-    return require('../runtime').console.c
-  }
-}
-function plots() { return require('../runtime').plots.pane }
-
-
-export function standard() {
-  let layout = {
-    split: true,
-    vertical: false,
-    items: [
-      null,
+export function queryDefaultLayout () {
+  const message = atom.notifications.addInfo('Julia-Client: Open Juno panes on startup ?', {
+    buttons: [
       {
-        split: false,
-        items: [workspace(), docs(), plots()]
+        text: 'Yes',
+        onDidClick: () => {
+          defaultLayout()
+          message.dismiss()
+          atom.config.set('julia-client.firstBoot', false)
+          atom.config.set('julia-client.uiOptions.layouts.openDefaultPanesOnStartUp', true)
+        }
+      },
+      {
+        text: 'No',
+        onDidClick: () => {
+          message.dismiss()
+          atom.config.set('julia-client.firstBoot', false)
+          atom.config.set('julia-client.uiOptions.layouts.openDefaultPanesOnStartUp', false)
+        }
       }
-    ]
-  }
-
-  resetLayout()
-
-  let centralpane = atom.workspace.getActivePane()
-
-  let ps = []
-  for (let pane of [workspace(), cons(), docs(), plots()]) ps.push(pane.close())
-  Promise.all(ps).then(() => {
-    resetLayout()
-    createLayout(layout)
-    atom.commands.dispatch(atom.views.getView(atom.workspace.getActivePane()), 'julia-client:open-console')
-    if (centralpane.activate) centralpane.activate()
+    ],
+    description: `You can specify panes to be opened and their default location and splitting rule
+    in 'Julia-Client > UI Options > Layout' settings. Use \`Julia-Client:Default-Layout\` command
+    to restore the layout at later point in time.`,
+    dismissable: true
   })
 }

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -1,50 +1,63 @@
 'use babel'
 
 const repl = () => {
-  return require('../runtime').console2.terminal.open({
-    split: atom.config.get('julia-client.uiOptions.layouts.console.split')
-  })
+  return require('../runtime').console2
 }
 const workspace = () => {
-  return require('../runtime').workspace.open()
+  return require('../runtime').workspace
 }
 const plotPane = () => {
-  return require('../runtime').plots.open()
+  return require('../runtime').plots
 }
 const debuggerPane = () => {
-  return require('../runtime').debugger.openPane()
+  return require('../runtime').debugger
 }
 const linter = () => {
-  return require('../runtime').linter.linterPane.ensureVisible({
-    split: atom.config.get('julia-client.uiOptions.layouts.linter.split')
-  })
+  return require('../runtime').linter
 }
 const documentation = () => {
-  return require('../ui').docpane.pane.open({
-    split: atom.config.get('julia-client.uiOptions.layouts.documentation.split')
-  })
+  return require('../ui').docpane
 }
 
 export function defaultLayout () {
-  const activeItem = atom.workspace.getActivePaneItem()
+  const activeContainer = atom.workspace.getActivePaneContainer()
   const activePane = atom.workspace.getActivePane()
+  const activeItem = atom.workspace.getActivePaneItem()
 
   const panes = []
-  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.console')) panes.push(repl())
-  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.workspace')) panes.push(workspace())
-  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.documentation')) panes.push(documentation())
-  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.plotPane')) panes.push(plotPane())
-  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.debuggerPane')) panes.push(debuggerPane())
-  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.linter')) panes.push(linter())
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.console')) panes.push(repl)
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.workspace')) panes.push(workspace)
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.documentation')) panes.push(documentation)
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.plotPane')) panes.push(plotPane)
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.debuggerPane')) panes.push(debuggerPane)
+  if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.linter')) panes.push(linter)
 
-  Promise.all(panes).then(() => {
-    activePane.focus()
-    activePane.activateItem(activeItem)
-  })
+  openPanes(panes)
+
+  // Re-activate the initially activated item
+  activeContainer.activate()
+  activePane.activate()
+  activePane.activateItem(activeItem)
+}
+
+function openPanes (panes) {
+  if (panes.length > 0) {
+    const pane = panes.shift()
+    const promise = pane().open()
+    promise.then(() => {
+      // Focus the previous active pane after each opening in order for this command to behave as if
+      // an user dispatch each opening command/action separately. In other word, this prevents
+      // multiple spliting from ending up in a funny state
+      const container = atom.workspace.getActivePaneContainer()
+      container.activatePreviousPane()
+      openPanes(panes)
+    })
+  }
+  return
 }
 
 export function queryDefaultLayout () {
-  const message = atom.notifications.addInfo('Julia-Client: Open Juno panes on startup ?', {
+  const message = atom.notifications.addInfo('Julia-Client: Open Juno-specific panes on startup ?', {
     buttons: [
       {
         text: 'Yes',
@@ -64,9 +77,10 @@ export function queryDefaultLayout () {
         }
       }
     ],
-    description: `You can specify panes to be opened and their default location and splitting rule
-    in 'Julia-Client > UI Options > Layout' settings. Use \`Julia-Client:Default-Layout\` command
-    to restore the layout at later point in time.`,
+    description:
+      `You can specify the panes to be opened and their _default location_ and _splitting rule_ in
+       **'Settings -> Julia-Client > UI Options > Layout'**.\n
+       Use \`Julia-Client:Default-Layout\` command to restore the layout at later point in time.`,
     dismissable: true
   })
 }

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -45,9 +45,10 @@ function openPanes (panes) {
     const pane = panes.shift()
     const promise = pane().open()
     promise.then(() => {
-      // Focus the previous active pane after each opening in order for this command to behave as if
-      // an user dispatch each opening command/action separately. In other word, this prevents
-      // multiple spliting from ending up in a funny state
+      // @NOTE: Focus the previously focused pane after each opening in order for this command to
+       // behave as if an user dispatch each opening command/action separately.
+       // In other word, this prevents opening multiple panes with the same splitting rule in a
+       // same location from ending up in a funny state
       const container = atom.workspace.getActivePaneContainer()
       container.activatePreviousPane()
       openPanes(panes)

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -71,7 +71,7 @@ function openPanes () {
 
 function openPanesHelper (panes) {
   if (panes.length === 0) {
-    // If there is no more pane to be opened, activate the first item in each pane, 
+    // If there is no more pane to be opened, activate the first item in each pane,
     // since Juno-panes are ordered so that "earlier-open, more important" above
     atom.workspace.getPanes().forEach(pane => {
       pane.activateItemAtIndex(0)
@@ -133,7 +133,7 @@ export function queryDefaultLayout () {
       `You can specify the panes to be opened and their _default location_ and _splitting rule_ in
        **\`'Settings -> Julia-Client > UI Options > Layout'\`**.\n
        \`Julia-Client:Default-Layout\` command will restore the layout at later point in time.
-       User \`Julia-Client:Reset-Layout-Settings\` command to reset the layout settings if it gets messed up`,
+       Use \`Julia-Client:Reset-Layout-Settings\` command to reset the layout settings if it gets messed up`,
     dismissable: true
   })
 }

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -1,10 +1,14 @@
 'use babel'
 
+// @NOTE: Sort panes by importance for `openPanesHelper`
 const repl = () => {
   return require('../runtime').console2
 }
 const workspace = () => {
   return require('../runtime').workspace
+}
+const documentation = () => {
+  return require('../ui').docpane
 }
 const plotPane = () => {
   return require('../runtime').plots
@@ -15,15 +19,8 @@ const debuggerPane = () => {
 const linter = () => {
   return require('../runtime').linter
 }
-const documentation = () => {
-  return require('../ui').docpane
-}
 
-export function defaultLayout () {
-  const activeContainer = atom.workspace.getActivePaneContainer()
-  const activePane = atom.workspace.getActivePane()
-  const activeItem = atom.workspace.getActivePaneItem()
-
+function specifiedPanes () {
   const panes = []
   if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.console')) panes.push(repl)
   if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.workspace')) panes.push(workspace)
@@ -32,29 +29,79 @@ export function defaultLayout () {
   if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.debuggerPane')) panes.push(debuggerPane)
   if (atom.config.get('julia-client.uiOptions.layouts.defaultPanes.linter')) panes.push(linter)
 
-  openPanes(panes)
-
-  // Re-activate the initially activated item
-  activeContainer.activate()
-  activePane.activate()
-  activePane.activateItem(activeItem)
+  return panes
 }
 
-function openPanes (panes) {
-  if (panes.length > 0) {
-    const pane = panes.shift()
-    const promise = pane().open()
-    promise.then(() => {
-      // @NOTE: Focus the previously focused pane after each opening in order for this command to
-       // behave as if an user dispatch each opening command/action separately.
-       // In other word, this prevents opening multiple panes with the same splitting rule in a
-       // same location from ending up in a funny state
-      const container = atom.workspace.getActivePaneContainer()
-      container.activatePreviousPane()
-      openPanes(panes)
+function closePromises () {
+  // Close only specified panes, i.e.: non-specified panes won't layouted
+  const panes = specifiedPanes()
+
+  const promises = panes.map(pane => {
+    return pane().close()
+  })
+
+  return promises
+}
+
+function bundlePanes () {
+  const containers = []
+  containers.push(atom.workspace.getCenter())
+  containers.push(atom.workspace.getLeftDock())
+  containers.push(atom.workspace.getBottomDock())
+  containers.push(atom.workspace.getRightDock())
+
+  containers.forEach(container => {
+    const panes = container.getPanes()
+    const firstPane = panes[0]
+    const otherPanes = panes.slice(1)
+    otherPanes.forEach(pane => {
+      const items = pane.getItems()
+      items.forEach(item => {
+        pane.moveItemToPane(item, firstPane)
+      })
     })
+  })
+}
+
+function openPanes () {
+  const panes = specifiedPanes()
+
+  openPanesHelper(panes)
+}
+
+function openPanesHelper (panes) {
+  if (panes.length === 0) {
+    // If there is no more pane to be opened, activate the first item in each pane, 
+    // since Juno-panes are ordered so that "earlier-open, more important" above
+    atom.workspace.getPanes().forEach(pane => {
+      pane.activateItemAtIndex(0)
+    })
+    return
   }
-  return
+
+  const pane = panes.shift()
+  pane().open().then(() => {
+    // Re-focust the previously focused pane (simplified pane by `bundlePanes`) after each opening
+    // This prevents opening multiple panes with the same splitting rule in a same location from
+    // ending up in a funny state
+    const container = atom.workspace.getActivePaneContainer()
+    container.activatePreviousPane()
+    openPanesHelper(panes)
+  })
+}
+
+export function defaultLayout () {
+  // Close Juno-specific panes first to reset to default layout
+  Promise.all(closePromises()).then(() => {
+
+    // Simplify layouts in each container to prevent funny splitting
+    bundlePanes()
+
+    // Open Juno-specific panes again
+    openPanes()
+  })
+}
+
 }
 
 export function queryDefaultLayout () {

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -102,6 +102,10 @@ export function defaultLayout () {
   })
 }
 
+export function resetLayoutSettings () {
+  const onStartup = atom.config.get('julia-client.uiOptions.layouts.openDefaultPanesOnStartUp')
+  atom.config.unset('julia-client.uiOptions.layouts')
+  atom.config.set('julia-client.uiOptions.layouts.openDefaultPanesOnStartUp', onStartup)
 }
 
 export function queryDefaultLayout () {
@@ -127,8 +131,9 @@ export function queryDefaultLayout () {
     ],
     description:
       `You can specify the panes to be opened and their _default location_ and _splitting rule_ in
-       **'Settings -> Julia-Client > UI Options > Layout'**.\n
-       Use \`Julia-Client:Default-Layout\` command to restore the layout at later point in time.`,
+       **\`'Settings -> Julia-Client > UI Options > Layout'\`**.\n
+       \`Julia-Client:Default-Layout\` command will restore the layout at later point in time.
+       User \`Julia-Client:Reset-Layout-Settings\` command to reset the layout settings if it gets messed up`,
     dismissable: true
   })
 }


### PR DESCRIPTION
### Rationale

Even though Juno's serialization works well, we still have to manually layout various panes at the beginning of the project or the later.
This PR addresses this by adding custom layout options so that users can set up their own default layout, i.e.: the default location and the splitting direction of any Juno pane.

### Approach

The possible drawback will be that these settings can be messed up. Thus I took the two approaches below:
1. Set the default settings to such values that they behave _exactly_ the same way as before
2. Made these settings collapsed by default so that users won't feel bother at them. Only users who want to tweak the default pane-opening settings, they can as they want.

Furthermore, I use [this new enum config settings](https://github.com/atom/settings-view/pull/1089) and I think these config seems rather neat:
![image](https://user-images.githubusercontent.com/40514306/58874039-b2be2180-8702-11e9-912d-8ea20852add6.png)


### Further Idea

If this custom layout options are approved, I also want to implement an optional functionality like `Restore Standard Layout on Start`:
It would be like "Opens user-selected panes on their desired location on startup except deserialized ones" and I believe this is much useful for some users.


### Notes

- [This](https://github.com/JunoLab/atom-ink/pull/203) is the PR on atom-ink side: It doesn't include any kind of atom-julia-client specific changes
- I additionally changed the variable-identifiers in files I modified to appropriate ones (like `let` to `const`). But if you feel bother about this, I can easily revert the changes since I put together those changes into the last commit.
