### PR TITLE
Add a command to toggle conditional breakpoint

### DIFF
--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -41,9 +41,9 @@ module.exports =
         @withInk ->
           boot()
           juno.runtime.evaluation.eval(cell: true, move: true)
-      'julia-client:next-cell': ->
+      'julia-client:next-cell': =>
         cells.moveNext()
-      'julia-client:prev-cell': ->
+      'julia-client:prev-cell': =>
         cells.movePrev()
       'julia-client:goto-symbol': =>
         @withInk ->
@@ -53,14 +53,14 @@ module.exports =
         @withInk ->
           boot()
           juno.runtime.evaluation.toggleDocs()
-      'julia-client:reset-workspace': ->
+      'julia-client:reset-workspace': =>
         requireClient 'reset the workspace', ->
           editor = atom.workspace.getActiveTextEditor()
           atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
           juno.connection.client.import('clear-workspace')()
-      'julia:select-block': ->
+      'julia:select-block': =>
         juno.misc.blocks.select()
-      'julia-client:send-to-stdin': (e) ->
+      'julia-client:send-to-stdin': (e) =>
         requireClient ->
           ed = e.currentTarget.getModel()
           done = false
@@ -80,8 +80,8 @@ module.exports =
       'julia-client:start-julia': -> disrequireClient 'boot Julia', -> boot()
       'julia-client:start-remote-julia-process': -> disrequireClient 'boot a remote Julia process', -> juno.connection.bootRemote()
       'julia-client:kill-julia': -> juno.connection.client.kill()
-      'julia-client:interrupt-julia': -> requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
-      'julia-client:disconnect-julia': -> requireClient 'disconnect Julia', -> juno.connection.client.disconnect()
+      'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
+      'julia-client:disconnect-julia': => requireClient 'disconnect Julia', -> juno.connection.client.disconnect()
       # 'julia-client:reset-julia-server': -> juno.connection.local.server.reset() # server mode not functional
       'julia-client:connect-external-process': -> disrequireClient -> juno.connection.messages.connectExternal()
       'julia-client:connect-platformio-terminal': -> disrequireClient -> juno.connection.terminal.runPlatformIOTerm()
@@ -89,17 +89,16 @@ module.exports =
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()
       'julia-client:open-workspace': => @withInk -> juno.runtime.workspace.open()
       'julia-client:settings': -> atom.workspace.open('atom://config/packages/julia-client')
-      'julia-debug:clear-all-breakpoints': -> juno.runtime.debugger.clearbps()
-      'julia-debug:toggle-breakpoint': -> juno.runtime.debugger.togglebp()
-      'julia-debug:toggle-conditional-breakpoint': -> juno.runtime.debugger.togglebp(true)
-      'julia-debug:step-to-next-line': -> juno.runtime.debugger.nextline()
-      'julia-debug:step-to-selected-line': -> juno.runtime.debugger.toselectedline()
-      'julia-debug:step-to-next-expression': -> juno.runtime.debugger.stepexpr()
-      'julia-debug:step-into-function': -> juno.runtime.debugger.stepin()
-      'julia-debug:stop-debugging': -> juno.runtime.debugger.stop()
-      'julia-debug:finish-function': -> juno.runtime.debugger.finish()
-      'julia-debug:continue': -> juno.runtime.debugger.continueForward()
-      'julia-debug:open-debugger-pane': -> juno.runtime.debugger.open()
+      'julia-debug:toggle-breakpoint': => juno.runtime.debugger.togglebp()
+      'julia-debug:toggle-conditional-breakpoint': => juno.runtime.debugger.togglebp(true)
+      'julia-debug:step-to-next-line': => juno.runtime.debugger.nextline()
+      'julia-debug:step-to-selected-line': => juno.runtime.debugger.toselectedline()
+      'julia-debug:step-to-next-expression': => juno.runtime.debugger.stepexpr()
+      'julia-debug:step-into-function': => juno.runtime.debugger.stepin()
+      'julia-debug:stop-debugging': => juno.runtime.debugger.stop()
+      'julia-debug:finish-function': => juno.runtime.debugger.finish()
+      'julia-debug:continue': => juno.runtime.debugger.continueForward()
+      'julia-debug:open-debugger-pane': => juno.runtime.debugger.openPane()
 
       'julia:open-julia-startup-file': -> atom.workspace.open(juno.misc.paths.home('.julia', 'config', 'startup.jl'))
       'julia:open-juno-startup-file': -> atom.workspace.open(juno.misc.paths.home('.julia', 'config', 'juno_startup.jl'))

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -89,8 +89,6 @@ module.exports =
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()
       'julia-client:open-workspace': => @withInk -> juno.runtime.workspace.open()
       'julia-client:settings': -> atom.workspace.open('atom://config/packages/julia-client')
-      # breakpoints not supported
-      'julia-debug:clear-all-breakpoints': => juno.runtime.debugger.clearbps()
       'julia-debug:get-all-breakpoints': => juno.runtime.debugger.getBPs()
       'julia-debug:toggle-breakpoint': => juno.runtime.debugger.togglebp()
       'julia-debug:step-to-next-line': => juno.runtime.debugger.nextline()
@@ -101,6 +99,7 @@ module.exports =
       'julia-debug:finish-function': => juno.runtime.debugger.finish()
       'julia-debug:continue': => juno.runtime.debugger.continueForward()
       'julia-debug:open-debugger-pane': => juno.runtime.debugger.openPane()
+      'julia-debug:toggle-conditional-breakpoint': -> juno.runtime.debugger.togglebp(true)
 
       'julia:open-julia-startup-file': -> atom.workspace.open(juno.misc.paths.home('.julia', 'config', 'startup.jl'))
       'julia:open-juno-startup-file': -> atom.workspace.open(juno.misc.paths.home('.julia', 'config', 'juno_startup.jl'))

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -91,6 +91,7 @@ module.exports =
       'julia-client:settings': -> atom.workspace.open('atom://config/packages/julia-client')
       'julia-debug:toggle-breakpoint': => juno.runtime.debugger.togglebp()
       'julia-debug:toggle-conditional-breakpoint': => juno.runtime.debugger.togglebp(true)
+      'julia-debug:clear-all-breakpoints': => juno.runtime.debugger.clearbps()
       'julia-debug:step-to-next-line': => juno.runtime.debugger.nextline()
       'julia-debug:step-to-selected-line': => juno.runtime.debugger.toselectedline()
       'julia-debug:step-to-next-expression': => juno.runtime.debugger.stepexpr()

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -41,9 +41,9 @@ module.exports =
         @withInk ->
           boot()
           juno.runtime.evaluation.eval(cell: true, move: true)
-      'julia-client:next-cell': =>
+      'julia-client:next-cell': ->
         cells.moveNext()
-      'julia-client:prev-cell': =>
+      'julia-client:prev-cell': ->
         cells.movePrev()
       'julia-client:goto-symbol': =>
         @withInk ->
@@ -53,14 +53,14 @@ module.exports =
         @withInk ->
           boot()
           juno.runtime.evaluation.toggleDocs()
-      'julia-client:reset-workspace': =>
+      'julia-client:reset-workspace': ->
         requireClient 'reset the workspace', ->
           editor = atom.workspace.getActiveTextEditor()
           atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
           juno.connection.client.import('clear-workspace')()
-      'julia:select-block': =>
+      'julia:select-block': ->
         juno.misc.blocks.select()
-      'julia-client:send-to-stdin': (e) =>
+      'julia-client:send-to-stdin': (e) ->
         requireClient ->
           ed = e.currentTarget.getModel()
           done = false
@@ -80,8 +80,8 @@ module.exports =
       'julia-client:start-julia': -> disrequireClient 'boot Julia', -> boot()
       'julia-client:start-remote-julia-process': -> disrequireClient 'boot a remote Julia process', -> juno.connection.bootRemote()
       'julia-client:kill-julia': -> juno.connection.client.kill()
-      'julia-client:interrupt-julia': => requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
-      'julia-client:disconnect-julia': => requireClient 'disconnect Julia', -> juno.connection.client.disconnect()
+      'julia-client:interrupt-julia': -> requireClient 'interrupt Julia', -> juno.connection.client.interrupt()
+      'julia-client:disconnect-julia': -> requireClient 'disconnect Julia', -> juno.connection.client.disconnect()
       # 'julia-client:reset-julia-server': -> juno.connection.local.server.reset() # server mode not functional
       'julia-client:connect-external-process': -> disrequireClient -> juno.connection.messages.connectExternal()
       'julia-client:connect-platformio-terminal': -> disrequireClient -> juno.connection.terminal.runPlatformIOTerm()
@@ -89,17 +89,17 @@ module.exports =
       'julia-client:open-plot-pane': => @withInk -> juno.runtime.plots.open()
       'julia-client:open-workspace': => @withInk -> juno.runtime.workspace.open()
       'julia-client:settings': -> atom.workspace.open('atom://config/packages/julia-client')
-      'julia-debug:get-all-breakpoints': => juno.runtime.debugger.getBPs()
-      'julia-debug:toggle-breakpoint': => juno.runtime.debugger.togglebp()
-      'julia-debug:step-to-next-line': => juno.runtime.debugger.nextline()
-      'julia-debug:step-to-selected-line': => juno.runtime.debugger.toselectedline()
-      'julia-debug:step-to-next-expression': => juno.runtime.debugger.stepexpr()
-      'julia-debug:step-into-function': => juno.runtime.debugger.stepin()
-      'julia-debug:stop-debugging': => juno.runtime.debugger.stop()
-      'julia-debug:finish-function': => juno.runtime.debugger.finish()
-      'julia-debug:continue': => juno.runtime.debugger.continueForward()
-      'julia-debug:open-debugger-pane': => juno.runtime.debugger.openPane()
+      'julia-debug:clear-all-breakpoints': -> juno.runtime.debugger.clearbps()
+      'julia-debug:toggle-breakpoint': -> juno.runtime.debugger.togglebp()
       'julia-debug:toggle-conditional-breakpoint': -> juno.runtime.debugger.togglebp(true)
+      'julia-debug:step-to-next-line': -> juno.runtime.debugger.nextline()
+      'julia-debug:step-to-selected-line': -> juno.runtime.debugger.toselectedline()
+      'julia-debug:step-to-next-expression': -> juno.runtime.debugger.stepexpr()
+      'julia-debug:step-into-function': -> juno.runtime.debugger.stepin()
+      'julia-debug:stop-debugging': -> juno.runtime.debugger.stop()
+      'julia-debug:finish-function': -> juno.runtime.debugger.finish()
+      'julia-debug:continue': -> juno.runtime.debugger.continueForward()
+      'julia-debug:open-debugger-pane': -> juno.runtime.debugger.open()
 
       'julia:open-julia-startup-file': -> atom.workspace.open(juno.misc.paths.home('.julia', 'config', 'startup.jl'))
       'julia:open-juno-startup-file': -> atom.workspace.open(juno.misc.paths.home('.julia', 'config', 'juno_startup.jl'))

--- a/lib/package/menu.coffee
+++ b/lib/package/menu.coffee
@@ -51,9 +51,10 @@ module.exports =
 
       {type: 'separator'}
 
-      {label: 'Open Plot Pane', command: 'julia-client:open-plot-pane'}
       {label: 'Open Workspace', command: 'julia-client:open-workspace'}
       {label: 'Open Documentation Browser', command: 'julia-client:open-documentation-browser'}
+      {label: 'Open Plot Pane', command: 'julia-client:open-plot-pane'}
+      {label: 'Open Debugger Pane', command: 'julia-client:open-debugger-pane'}
 
       {type: 'separator'}
 

--- a/lib/runtime/debugger.js
+++ b/lib/runtime/debugger.js
@@ -178,14 +178,27 @@ function setLevel (level) {
   return client.import('setStackLevel')(level)
 }
 
-export function togglebp(ed = atom.workspace.getActiveTextEditor()) {
+export function togglebp (
+  cond = false,
+  ed = atom.workspace.getActiveTextEditor()
+) {
   if (!ed || !ed.getPath()) {
     atom.notifications.addError('Need a saved file to add a breakpoint')
     return
   }
-  ed.getCursors().map((cursor) =>
-    breakpoints.toggleAtSourceLocation({
-      file: client.editorPath(ed),
-      line: cursor.getBufferPosition().row + 1
-    }))
+  const file = client.editorPath(ed)
+  ed.getCursors().map((cursor) => {
+    const line = cursor.getBufferPosition().row + 1
+    if (cond) {
+      breakpoints.toggleConditionAtSourceLocation({
+        file: file,
+        line: line
+      })
+    } else {
+      breakpoints.toggleAtSourceLocation({
+        file: file,
+        line: line
+      })
+    }
+  })
 }

--- a/menus/julia-client.cson
+++ b/menus/julia-client.cson
@@ -1,8 +1,18 @@
 'context-menu':
   'atom-text-editor[data-grammar="source julia"]': [
-    {label: 'Run Block', command: 'julia-client:run-block'}
-    {label: 'Go to Definition', command: 'julia-client:goto-symbol'}
-    {label: 'Show Documentation', command: 'julia-client:show-documentation'}
-    # {label: 'Toggle breakpoint', command: 'julia-debug:toggle-breakpoint'}
+    {type: 'separator'}
+
+    {
+      label: 'Julia-Client',
+      submenu: [
+        {label: 'Run Block', command: 'julia-client:run-block'}
+        {label: 'Select Block', command: 'julia-client:select-block'}
+        {label: 'Go to Definition', command: 'julia-client:goto-symbol'}
+        {label: 'Show Documentation', command: 'julia-client:show-documentation'}
+        {label: 'Toggle Breakpoint', command: 'julia-debug:toggle-breakpoint'}
+        {label: 'Toggle Conditional Breakpoint', command: 'julia-debug:toggle-conditional-breakpoint'}
+      ]
+    }
+
     {type: 'separator'}
   ]


### PR DESCRIPTION
This PR enables an user to easily create a conditional breakpoint.

Behaviour of `toggle-conditional-breakpoint`:
- If there is no breakpoint: Create a brand new conditional breakpoint
- If there is already a non-conditional/conditional breakpoint: Edit its condition

The corresponding PR in atom-ink: https://github.com/JunoLab/atom-ink/pull/204