### PR TITLE
Make Julia-Client more grammar-sensible

### DIFF
--- a/keymaps/julia-client.cson
+++ b/keymaps/julia-client.cson
@@ -7,7 +7,7 @@
 '.platform-darwin .item-views > atom-text-editor[data-grammar="source julia"]':
   'cmd-enter': 'julia-client:run-block'
   'shift-enter': 'julia-client:run-and-move'
-  'cmd-shift-enter': 'julia-client:run-file'
+  'cmd-shift-enter': 'julia-client:run-all'
   'alt-enter': 'julia-client:run-cell'
   'alt-shift-enter': 'julia-client:run-cell-and-move'
   'alt-down': 'julia-client:next-cell'
@@ -48,7 +48,7 @@
  .platform-linux .item-views > atom-text-editor[data-grammar="source julia"]':
   'ctrl-enter': 'julia-client:run-block'
   'shift-enter': 'julia-client:run-and-move'
-  'ctrl-shift-enter': 'julia-client:run-file'
+  'ctrl-shift-enter': 'julia-client:run-all'
   'alt-enter': 'julia-client:run-cell'
   'alt-shift-enter': 'julia-client:run-cell-and-move'
   'alt-down': 'julia-client:next-cell'

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -24,16 +24,11 @@ module.exports =
           @withInk ->
             boot()
             juno.runtime.evaluation.eval(move: true)
-        'julia-client:run-file': (event) =>
+        'julia-client:run-all': (event) =>
           cancelComplete event
           @withInk ->
             boot()
             juno.runtime.evaluation.evalAll()
-        'julia-client:run-weave-chunks': (event) =>
-          cancelComplete event
-          @withInk ->
-            boot()
-            juno.runtime.evaluation.evalAllWeaveChunks()
         'julia-client:run-cell': =>
           @withInk ->
             boot()

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -1,5 +1,5 @@
-shell =                 require 'shell'
-cells =                 require '../misc/cells'
+shell                 = require 'shell'
+cells                 = require '../misc/cells'
 {CompositeDisposable} = require 'atom'
 
 module.exports =
@@ -13,63 +13,64 @@ module.exports =
 
     @subs = new CompositeDisposable()
 
-    @subs.add atom.commands.add '.item-views > atom-text-editor',
-      'julia-client:run-block': (event) =>
-        cancelComplete event
-        @withInk ->
-          boot()
-          juno.runtime.evaluation.eval()
-      'julia-client:run-and-move': (event) =>
-        @withInk ->
-          boot()
-          juno.runtime.evaluation.eval(move: true)
-      'julia-client:run-file': (event) =>
-        cancelComplete event
-        @withInk ->
-          boot()
-          juno.runtime.evaluation.evalAll()
-      'julia-client:run-weave-chunks': (event) =>
-        cancelComplete event
-        @withInk ->
-          boot()
-          juno.runtime.evaluation.evalAllWeaveChunks()
-      'julia-client:run-cell': =>
-        @withInk ->
-          boot()
-          juno.runtime.evaluation.eval(cell: true)
-      'julia-client:run-cell-and-move': =>
-        @withInk ->
-          boot()
-          juno.runtime.evaluation.eval(cell: true, move: true)
-      'julia-client:next-cell': =>
-        cells.moveNext()
-      'julia-client:prev-cell': =>
-        cells.movePrev()
-      'julia-client:goto-symbol': =>
-        @withInk ->
-          boot()
-          juno.runtime.evaluation.gotoSymbol()
-      'julia-client:show-documentation': =>
-        @withInk ->
-          boot()
-          juno.runtime.evaluation.toggleDocs()
-      'julia-client:reset-workspace': =>
-        requireClient 'reset the workspace', ->
-          editor = atom.workspace.getActiveTextEditor()
-          atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
-          juno.connection.client.import('clear-workspace')()
-      'julia:select-block': =>
-        juno.misc.blocks.select()
-      'julia-client:send-to-stdin': (e) =>
-        requireClient ->
-          ed = e.currentTarget.getModel()
-          done = false
-          for s in ed.getSelections()
-            continue unless s.getText()
-            done = true
-            juno.connection.client.stdin s.getText()
-          juno.connection.client.stdin ed.getText() unless done
-
+    for scope in atom.config.get('julia-client.juliaSyntaxScopes')
+      @subs.add atom.commands.add ".item-views > atom-text-editor[data-grammar='#{scope.replace /\./g, ' '}']",
+        'julia-client:run-block': (event) =>
+          cancelComplete event
+          @withInk ->
+            boot()
+            juno.runtime.evaluation.eval()
+        'julia-client:run-and-move': (event) =>
+          @withInk ->
+            boot()
+            juno.runtime.evaluation.eval(move: true)
+        'julia-client:run-file': (event) =>
+          cancelComplete event
+          @withInk ->
+            boot()
+            juno.runtime.evaluation.evalAll()
+        'julia-client:run-weave-chunks': (event) =>
+          cancelComplete event
+          @withInk ->
+            boot()
+            juno.runtime.evaluation.evalAllWeaveChunks()
+        'julia-client:run-cell': =>
+          @withInk ->
+            boot()
+            juno.runtime.evaluation.eval(cell: true)
+        'julia-client:run-cell-and-move': =>
+          @withInk ->
+            boot()
+            juno.runtime.evaluation.eval(cell: true, move: true)
+        'julia-client:next-cell': =>
+          cells.moveNext()
+        'julia-client:prev-cell': =>
+          cells.movePrev()
+        'julia-client:goto-symbol': =>
+          @withInk ->
+            boot()
+            juno.runtime.evaluation.gotoSymbol()
+        'julia-client:show-documentation': =>
+          @withInk ->
+            boot()
+            juno.runtime.evaluation.toggleDocs()
+        # @NOTE: `'clear-workspace'` is now not handled by Atom.jl
+        # 'julia-client:reset-workspace': =>
+        #   requireClient 'reset the workspace', ->
+        #     editor = atom.workspace.getActiveTextEditor()
+        #     atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
+        #     juno.connection.client.import('clear-workspace')()
+        'julia:select-block': =>
+          juno.misc.blocks.select()
+        'julia-client:send-to-stdin': (e) =>
+          requireClient ->
+            ed = e.currentTarget.getModel()
+            done = false
+            for s in ed.getSelections()
+              continue unless s.getText()
+              done = true
+              juno.connection.client.stdin s.getText()
+            juno.connection.client.stdin ed.getText() unless done
 
     @subs.add atom.commands.add '.item-views > atom-text-editor[data-grammar="source julia"],
                                  .julia-console.julia, ink-terminal, .ink-workspace',

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -455,6 +455,15 @@ config =
         type: 'boolean'
         default: true
         order: 5
+  juliaSyntaxScopes:
+    title: 'Julia Syntax Scopes'
+    description:
+      'The listed syntax scopes (comma separated) will be recoginized as julia files.
+       Requires Atom to be restarted to take an effect.\n
+       **DO NOT** edit this unless you\'re sure about the effect.'
+    type: 'array'
+    default: ['source.julia', 'source.weave.md', 'source.weave.latex']
+    order: 6
 
   firstBoot:
     type: 'boolean'

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -458,7 +458,7 @@ config =
   juliaSyntaxScopes:
     title: 'Julia Syntax Scopes'
     description:
-      'The listed syntax scopes (comma separated) will be recoginized as julia files.
+      'The listed syntax scopes (comma separated) will be recoginized as Julia files.
        You may have to restart Atom to take an effect.\n
        **DO NOT** edit this unless you\'re sure about the effect.'
     type: 'array'

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -459,7 +459,7 @@ config =
     title: 'Julia Syntax Scopes'
     description:
       'The listed syntax scopes (comma separated) will be recoginized as julia files.
-       Requires Atom to be restarted to take an effect.\n
+       You may have to restart Atom to take an effect.\n
        **DO NOT** edit this unless you\'re sure about the effect.'
     type: 'array'
     default: ['source.julia', 'source.weave.md', 'source.weave.latex']

--- a/lib/package/menu.coffee
+++ b/lib/package/menu.coffee
@@ -38,7 +38,7 @@ module.exports =
       {type: 'separator'}
 
       {label: 'Run Block', command: 'julia-client:run-block'}
-      {label: 'Run File', command: 'julia-client:run-file'}
+      {label: 'Run All', command: 'julia-client:run-all'}
       {label: 'Open Console', command: 'julia-client:open-console'}
       {label: 'Clear Console', command: 'julia-client:clear-console'}
 

--- a/lib/package/toolbar.coffee
+++ b/lib/package/toolbar.coffee
@@ -74,8 +74,8 @@ module.exports =
 
     @bar.addButton
       icon: 'play'
-      callback: 'julia-client:run-file'
-      tooltip: 'Run File'
+      callback: 'julia-client:run-all'
+      tooltip: 'Run All'
       iconset: 'ion'
 
     @bar.addButton

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -12,14 +12,21 @@ modules = require './modules'
     client.import rpc: ['eval', 'evalall', 'evalrepl', 'evalshow'], msg: ['cd', 'clearLazy']
 
 module.exports =
-  currentContext: ->
+  _currentContext: ->
     editor = atom.workspace.getActiveTextEditor()
     mod = modules.current() ? 'Main'
     edpath = client.editorPath(editor) || 'untitled-' + editor.getBuffer().id
     {editor, mod, edpath}
 
+  _showError: (r, lines) ->
+    @errorLines?.lights.destroy()
+    lights = @ink.highlights.errorLines (file: file, line: line-1 for {file, line} in lines)
+    @errorLines = {r, lights}
+    r.onDidDestroy =>
+      if @errorLines?.r == r then @errorLines.lights.destroy()
+
   eval: ({move, cell}={}) ->
-    {editor, mod, edpath} = @currentContext()
+    {editor, mod, edpath} = @_currentContext()
     selector = if cell? then cells else blocks
     Promise.all selector.get(editor).map ({range, line, text, selection}) =>
       selector.moveNext editor, selection, range if move
@@ -51,14 +58,14 @@ module.exports =
               editor.onDidDestroy client.withCurrent -> clearLazy id
             r.setContent views.render(view, {registerLazy}), {error}
             if error and result.highlights?
-              @showError r, result.highlights
+              @_showError r, result.highlights
             atom.beep() if error
             notifications.show "Evaluation Finished"
             workspace.update()
             result
 
   evalAll: ->
-    {editor, edpath} = @currentContext()
+    {editor, edpath} = @_currentContext()
     atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
     evalall({
               path: edpath
@@ -69,7 +76,7 @@ module.exports =
         workspace.update()
 
   evalAllWeaveChunks: ->
-    {editor, mod, edpath} = @currentContext()
+    {editor, mod, edpath} = @_currentContext()
     atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
     evalall({
               path: edpath
@@ -93,14 +100,14 @@ module.exports =
     }
 
   gotoSymbol: (word, range) ->
-    {editor, mod, edpath} = @currentContext()
+    {editor, mod, edpath} = @_currentContext()
     {word, range} = words.getWord(editor) unless word? and range?
     if word.length == 0 || !isNaN(word) then return
     client.import("methods")({word: word, mod: mod}).then (symbols) =>
       @ink.goto.goto symbols unless symbols.error
 
   toggleDocs: (word, range) ->
-    {editor, mod, edpath} = @currentContext()
+    {editor, mod, edpath} = @_currentContext()
     {word, range} = words.getWord(editor) unless word? and range?
     if word.length == 0 || !isNaN(word) then return
     client.import("docs")({word: word, mod: mod}).then (result) =>
@@ -116,14 +123,12 @@ module.exports =
         docpane.ensureVisible()
         docpane.showDocument(v, [])
 
-  showError: (r, lines) ->
-    @errorLines?.lights.destroy()
-    lights = @ink.highlights.errorLines (file: file, line: line-1 for {file, line} in lines)
-    @errorLines = {r, lights}
-    r.onDidDestroy =>
-      if @errorLines?.r == r then @errorLines.lights.destroy()
-
   # Working Directory
+
+  _cd: (dir) ->
+    if atom.config.get('julia-client.juliaOptions.persistWorkingDir')
+      atom.config.set('julia-client.juliaOptions.workingDir', dir)
+    cd(dir)
 
   cdHere: ->
     file = client.editorPath(atom.workspace.getActiveTextEditor())
@@ -148,8 +153,3 @@ module.exports =
     opts = properties: ['openDirectory']
     dialog.showOpenDialog BrowserWindow.getFocusedWindow(), opts, (path) =>
       if path? then @_cd path[0]
-
-  _cd: (dir) ->
-    if atom.config.get('julia-client.juliaOptions.persistWorkingDir')
-      atom.config.set('julia-client.juliaOptions.workingDir', dir)
-    cd(dir)

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -81,6 +81,8 @@ module.exports =
 
   provideHyperclick: () ->
     {
+      providerName: 'julia-client-hyperclick-provider'
+      grammarScopes: atom.config.get('julia-client.juliaSyntaxScopes')
       wordRegExp:  new RegExp(words.wordRegex, "g")
       getSuggestionForWord: (editor, text, range) =>
         require('../connection').boot()

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -65,26 +65,19 @@ module.exports =
             result
 
   evalAll: ->
-    {editor, edpath} = @_currentContext()
-    atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
-    evalall({
-              path: edpath
-              module: editor.juliaModule
-              code: editor.getText()
-            }).then (result) ->
-        notifications.show "Evaluation Finished"
-        workspace.update()
-
-  evalAllWeaveChunks: ->
     {editor, mod, edpath} = @_currentContext()
     atom.commands.dispatch atom.views.getView(editor), 'inline-results:clear-all'
+    [scope] = editor.getRootScopeDescriptor().getScopesArray()
+    weaveScopes = ['source.weave.md', 'source.weave.latex']
+    module = if weaveScopes.includes scope then mod else editor.juliaModule
+    code = if weaveScopes.includes scope then weave.getCode editor else editor.getText()
     evalall({
-              path: edpath
-              module: mod
-              code: weave.getCode(editor)
-            }).then (result) ->
-        notifications.show "Evaluation Finished"
-        workspace.update()
+      path: edpath
+      module: module
+      code: code
+    }).then (result) ->
+      notifications.show "Evaluation Finished"
+      workspace.update()
 
   provideHyperclick: () ->
     {

--- a/spec/eval.coffee
+++ b/spec/eval.coffee
@@ -10,7 +10,8 @@ module.exports = ->
   waitsForClient = -> waitsFor (done) -> client.onceDone done
 
   beforeEach ->
-    waitsForPromise -> atom.workspace.open().then (ed) -> editor = ed
+    # waitsForPromise -> atom.workspace.open().then (ed) -> editor = ed
+    editor = atom.workspace.buildTextEditor()
     runs ->
       editor.setGrammar(atom.grammars.grammarForScopeName('source.julia'))
 

--- a/spec/juno-spec.coffee
+++ b/spec/juno-spec.coffee
@@ -6,6 +6,9 @@ if process.platform is 'darwin'
 
 basicSetup = ->
   jasmine.attachToDOM atom.views.getView atom.workspace
+  waitsForPromise -> atom.packages.activatePackage 'language-julia'
+  waitsForPromise -> atom.packages.activatePackage 'ink'
+  waitsForPromise -> atom.packages.activatePackage 'julia-client'
   runs ->
     atom.config.set 'julia-client',
       juliaPath: 'julia'
@@ -13,15 +16,8 @@ basicSetup = ->
         bootMode: 'Basic'
         optimisationLevel: 2
         deprecationWarnings: false
-      uiOptions:
-        layouts:
-          openDefaultPanesOnStartUp: false
       consoleOptions:
         rendererType: true
-      firstBoot: false
-  waitsForPromise -> atom.packages.activatePackage 'language-julia'
-  waitsForPromise -> atom.packages.activatePackage 'ink'
-  waitsForPromise -> atom.packages.activatePackage 'julia-client'
 
 cyclerSetup = ->
   basicSetup()

--- a/spec/juno-spec.coffee
+++ b/spec/juno-spec.coffee
@@ -6,18 +6,22 @@ if process.platform is 'darwin'
 
 basicSetup = ->
   jasmine.attachToDOM atom.views.getView atom.workspace
+  runs ->
+    atom.config.set 'julia-client',
+      juliaPath: 'julia'
+      juliaOptions:
+        bootMode: 'Basic'
+        optimisationLevel: 2
+        deprecationWarnings: false
+      uiOptions:
+        layouts:
+          openDefaultPanesOnStartUp: false
+      consoleOptions:
+        rendererType: true
+      firstBoot: false
   waitsForPromise -> atom.packages.activatePackage 'language-julia'
   waitsForPromise -> atom.packages.activatePackage 'ink'
   waitsForPromise -> atom.packages.activatePackage 'julia-client'
-  runs ->
-    atom.config.set 'julia-client.juliaPath', 'julia'
-    atom.config.set 'julia-client.juliaOptions',
-      bootMode: 'Basic'
-      optimisationLevel: 2
-      deprecationWarnings: false
-      precompiled: true
-      consoleOptions:
-        rendererType: true
 
 cyclerSetup = ->
   basicSetup()


### PR DESCRIPTION
## Improvements

- Make config for setting scopes that Julia-Client would recognise as Julia file:
    * Default to `['source.julia', 'source.weave.md', 'source.weave.latex']`
- Disable `provideHyperclick` for non-Julia files
- Register `atom-text-editor` specific commands only for Julia `atom-text^editor`s

## Ideas

- [x] It's less intuitive that currently Juno registers `julia-client:run-weave-chunks` to `source.julia` and the same for `julia-client:run-file` to `source.weave`. Rather, I want to migrate them into `julia-client:run-all`. (`julia-client:run-cell` runs correctly both for `source.julia` and `source.weave` and it would be nice if `julia-client:run-all` behaves the same way, say, in a same way as Julia's multiple dispatch 😁 )
- [ ] Add `activationHooks` ??:
     * Can speed up package loading time for non-Julia projects: but atst can cause unexpected states around serialization: Once atom-ink is merged into julia-client, this would need more tweaks that moving serialization into package.json.