### PR TITLE
Create command to format code in a current editor

### DIFF
--- a/keymaps/julia-client.cson
+++ b/keymaps/julia-client.cson
@@ -14,6 +14,7 @@
   'alt-up': 'julia-client:prev-cell'
   'cmd-j cmd-d': 'julia-client:show-documentation'
   'cmd-shift-a': 'julia:select-block'
+  'cmd-j cmd-f': 'julia-client:format-code'
   'ctrl-x': 'julia-debug:toggle-breakpoint'
   'cmd-j cmd-g': 'julia-client:goto-symbol'
 
@@ -54,6 +55,7 @@
   'alt-down': 'julia-client:next-cell'
   'alt-up': 'julia-client:prev-cell'
   'ctrl-j ctrl-m': 'julia-client:set-working-module'
+  'ctrl-j ctrl-f': 'julia-client:format-code'
   'ctrl-shift-c': 'julia-client:interrupt-julia'
   'ctrl-j ctrl-d': 'julia-client:show-documentation'
   'alt-x': 'julia-debug:toggle-breakpoint'

--- a/keymaps/julia-client.cson
+++ b/keymaps/julia-client.cson
@@ -1,52 +1,60 @@
-# It's best not to override default Atom keybindings if possible, and then only
-# in julia-scoped places (e.g. Julia-syntax buffer, console)
+###
+@NOTE
+It's best not to override default Atom keybindings if possible, and then
+register only in Julia-scoped places (e.g. Julia-syntax buffer, console)
+Any global commands should either be non-default or, ideally, prefixed with `C-J`.
+###
 
-# Any global commands should either be non-default or, ideally, prefixed with
-# `C-J`.
+## Common
+# Debug operations
+'atom-text-editor[data-grammar="source julia"]':
+  'f10': 'julia-debug:step-to-next-expression'
+  'f11': 'julia-debug:step-into-function'
+  'shift-f11': 'julia-debug:finish-function'
 
-'.platform-darwin .item-views > atom-text-editor[data-grammar="source julia"]':
+
+## macOS
+# Julia atom-text-editor
+'.platform-darwin atom-text-editor[data-grammar="source julia"]':
   'cmd-enter': 'julia-client:run-block'
   'shift-enter': 'julia-client:run-and-move'
   'cmd-shift-enter': 'julia-client:run-all'
   'alt-enter': 'julia-client:run-cell'
   'alt-shift-enter': 'julia-client:run-cell-and-move'
+  'cmd-shift-a': 'julia-client:select-block'
   'alt-down': 'julia-client:next-cell'
   'alt-up': 'julia-client:prev-cell'
+  'cmd-j cmd-g': 'julia-client:goto-symbol'
   'cmd-j cmd-d': 'julia-client:show-documentation'
-  'cmd-shift-a': 'julia:select-block'
+  'cmd-j cmd-m': 'julia-client:set-working-module'
   'cmd-j cmd-f': 'julia-client:format-code'
   'ctrl-x': 'julia-debug:toggle-breakpoint'
-  'cmd-j cmd-g': 'julia-client:goto-symbol'
+  'ctrl-shift-x': 'julia-debug:toggle-conditional-breakpoint'
 
-'.platform-darwin .item-views > atom-text-editor[data-grammar="source julia"],
- .platform-darwin .julia-console.julia,
- .platform-darwin .julia-console.julia atom-text-editor,
- .platform-darwin .julia-terminal':
+# Julia REPL
+'.platform-darwin .julia-terminal':
   'ctrl-c': 'julia-client:interrupt-julia'
   'cmd-j cmd-m': 'julia-client:set-working-module'
 
-'.platform-darwin .item-views > atom-text-editor[data-grammar="source julia"].debug,
- .platform-darwin .julia-console.julia.debug,
- .platform-darwin .julia-console.julia.debug atom-text-editor':
-  'ctrl-l': 'julia-debug:step-to-next-line'
-  'ctrl-m': 'julia-debug:step-to-next-expression'
-  'ctrl-f': 'julia-debug:finish-function'
-  'ctrl-s': 'julia-debug:step-into-function'
-
+# atom-workspace
 '.platform-darwin atom-workspace':
   'cmd-j cmd-r': 'julia-client:open-a-repl'
-  'cmd-j cmd-s': 'julia-client:start-julia'
   'cmd-j cmd-o': 'julia-client:open-console'
-  'cmd-j cmd-p': 'julia-client:open-plot-pane'
   'cmd-j cmd-c': 'julia-client:clear-console'
+  'cmd-j cmd-s': 'julia-client:start-julia'
   'cmd-j cmd-k': 'julia-client:kill-julia'
+  'cmd-j cmd-p': 'julia-client:open-plot-pane'
+  'cmd-j cmd-w': 'julia-client:open-workspace'
   'cmd-j cmd-,': 'julia-client:settings'
   'cmd-j cmd-e': 'julia-client:focus-last-editor'
   'cmd-j cmd-t': 'julia-client:focus-last-terminal'
   'cmd-j cmd-b': 'julia-client:return-from-goto'
 
-'.platform-win32 .item-views > atom-text-editor[data-grammar="source julia"],
- .platform-linux .item-views > atom-text-editor[data-grammar="source julia"]':
+
+## Windows & Linux
+# Julia atom-text-editor
+'.platform-win32 atom-text-editor[data-grammar="source julia"],
+ .platform-linux atom-text-editor[data-grammar="source julia"]':
   'ctrl-enter': 'julia-client:run-block'
   'shift-enter': 'julia-client:run-and-move'
   'ctrl-shift-enter': 'julia-client:run-all'
@@ -54,50 +62,33 @@
   'alt-shift-enter': 'julia-client:run-cell-and-move'
   'alt-down': 'julia-client:next-cell'
   'alt-up': 'julia-client:prev-cell'
+  'ctrl-j ctrl-g': 'julia-client:goto-symbol'
+  'ctrl-j ctrl-d': 'julia-client:show-documentation'
   'ctrl-j ctrl-m': 'julia-client:set-working-module'
   'ctrl-j ctrl-f': 'julia-client:format-code'
   'ctrl-shift-c': 'julia-client:interrupt-julia'
-  'ctrl-j ctrl-d': 'julia-client:show-documentation'
   'alt-x': 'julia-debug:toggle-breakpoint'
-  'ctrl-j ctrl-g': 'julia-client:goto-symbol'
+  'alt-shift-x': 'julia-debug:toggle-conditional-breakpoint'
 
-'.platform-win32 .julia-console.julia,
- .platform-win32 .julia-console.julia atom-text-editor,
- .platform-linux .julia-console.julia,
- .platform-linux .julia-console.julia atom-text-editor':
-  'ctrl-shift-c': 'julia-client:interrupt-julia'
-  'ctrl-j ctrl-m': 'julia-client:set-working-module'
-
-'.platform-win32 .julia-terminal, .platform-linux .julia-terminal':
+# Julia REPL
+'.platform-win32 .julia-terminal,
+ .platform-linux .julia-terminal':
   'ctrl-j ctrl-m': 'julia-client:set-working-module'
   'ctrl-c': 'julia-client:copy-or-interrupt'
   'ctrl-shift-c': 'julia-client:copy-or-interrupt'
   'ctrl-v': 'ink-terminal:paste'
 
+# atom-workspace
 '.platform-win32 atom-workspace,
  .platform-linux atom-workspace':
   'ctrl-j ctrl-r': 'julia-client:open-a-repl'
-  'ctrl-j ctrl-s': 'julia-client:start-julia'
   'ctrl-j ctrl-o': 'julia-client:open-console'
-  'ctrl-j ctrl-p': 'julia-client:open-plot-pane'
   'ctrl-j ctrl-c': 'julia-client:clear-console'
+  'ctrl-j ctrl-s': 'julia-client:start-julia'
   'ctrl-j ctrl-k': 'julia-client:kill-julia'
+  'ctrl-j ctrl-p': 'julia-client:open-plot-pane'
+  'ctrl-j ctrl-w': 'julia-client:open-workspace'
   'ctrl-j ctrl-,': 'julia-client:settings'
   'ctrl-j ctrl-e': 'julia-client:focus-last-editor'
   'ctrl-j ctrl-t': 'julia-client:focus-last-terminal'
   'ctrl-j ctrl-b': 'julia-client:return-from-goto'
-
-'.platform-win32 ink-console atom-text-editor:not([mini]),
- .platform-linux ink-console atom-text-editor:not([mini])':
-  'ctrl-enter': 'editor:newline'
-
-'.platform-darwin ink-console atom-text-editor:not([mini])':
-  'cmd-enter': 'editor:newline'
-
-'ink-console atom-text-editor:not([mini])':
-  'alt-enter': 'editor:newline'
-
-'atom-text-editor[data-grammar="source julia"]':
-  'f10': 'julia-debug:step-to-next-expression'
-  'f11': 'julia-debug:step-into-function'
-  'shift-f11': 'julia-debug:finish-function'

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -175,7 +175,7 @@ module.exports =
   connectedError: (action = 'do that') ->
     if @isActive()
       atom.notifications.addError "Can't #{action} with a Julia client running.",
-        description: "Stop the current client with Packages → Julia → Stop Julia."
+        description: "Stop the current client with `Packages -> Julia -> Stop Julia`."
       true
     else
       false
@@ -183,7 +183,7 @@ module.exports =
   notConnectedError: (action = 'do that') ->
     if not @isActive()
       atom.notifications.addError "Can't #{action} without a Julia client running.",
-        description: "Start Julia using **`Julia-Client: Start-Julia`** command."
+        description: "Start a client with `Packages -> Julia -> Start Julia`."
       true
     else
       false

--- a/lib/connection/client.coffee
+++ b/lib/connection/client.coffee
@@ -183,7 +183,7 @@ module.exports =
   notConnectedError: (action = 'do that') ->
     if not @isActive()
       atom.notifications.addError "Can't #{action} without a Julia client running.",
-        description: "Start Julia using Packages → Julia → Start Julia."
+        description: "Start Julia using **`Julia-Client: Start-Julia`** command."
       true
     else
       false

--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -69,6 +69,9 @@ module.exports =
 
     @subs.add atom.commands.add '.item-views > atom-text-editor[data-grammar="source julia"],
                                  .julia-console.julia, ink-terminal, .ink-workspace',
+    @subs.add atom.commands.add 'atom-text-editor[data-grammar="source julia"]',
+      'julia-client:format-code': =>
+        requireClient 'format code', => juno.runtime.formatter.formatCode()
       'julia-client:set-working-module': -> juno.runtime.modules.chooseModule()
 
     @subs.add atom.commands.add 'atom-workspace',

--- a/lib/package/menu.coffee
+++ b/lib/package/menu.coffee
@@ -23,6 +23,7 @@ module.exports =
     label: 'Julia'
     submenu: [
       {label: 'Start Julia', command: 'julia-client:start-julia'}
+      {label: 'Start Remote Julia Process', command: 'julia-client:start-remote-julia-process'}
       {label: 'Interrupt Julia', command: 'julia-client:interrupt-julia'}
       {label: 'Stop Julia', command: 'julia-client:kill-julia'}
       {label: 'Open Console', command: 'julia-client:open-console'}

--- a/lib/package/menu.coffee
+++ b/lib/package/menu.coffee
@@ -23,8 +23,11 @@ module.exports =
     label: 'Julia'
     submenu: [
       {label: 'Start Julia', command: 'julia-client:start-julia'}
+      {label: 'Interrupt Julia', command: 'julia-client:interrupt-julia'}
       {label: 'Stop Julia', command: 'julia-client:kill-julia'}
-      {label: 'Open Terminal', command: 'julia-client:open-a-repl'}
+      {label: 'Open Console', command: 'julia-client:open-console'}
+      {label: 'Clear Console', command: 'julia-client:clear-console'}
+      {label: 'Open REPL', command: 'julia-client:open-a-repl'}
       {
         label: 'Working Directory'
         submenu: [
@@ -34,20 +37,18 @@ module.exports =
           {label: 'Select...', command: 'julia-client:select-working-folder'}
         ]
       }
+      {
+        label: 'Working Module'
+        submenu: [
+          {label: 'Select...', command: 'julia-client:select-working-module'}
+        ]
+      }
 
       {type: 'separator'}
 
       {label: 'Run Block', command: 'julia-client:run-block'}
       {label: 'Run All', command: 'julia-client:run-all'}
-      {label: 'Open Console', command: 'julia-client:open-console'}
-      {label: 'Clear Console', command: 'julia-client:clear-console'}
-
-      {type: 'separator'}
-
-      {label: 'Open Julia Startup File', command: 'julia:open-julia-startup-file'}
-      {label: 'Open Juno Startup File', command: 'julia:open-juno-startup-file'}
-      {label: 'Open Julia Home', command: 'julia:open-julia-home'}
-      {label: 'Open Package in New Window...', command: 'julia:open-package-in-new-window'}
+      {label: 'Format Code', command: 'julia-client:format-code'}
 
       {type: 'separator'}
 
@@ -55,6 +56,13 @@ module.exports =
       {label: 'Open Documentation Browser', command: 'julia-client:open-documentation-browser'}
       {label: 'Open Plot Pane', command: 'julia-client:open-plot-pane'}
       {label: 'Open Debugger Pane', command: 'julia-client:open-debugger-pane'}
+
+      {type: 'separator'}
+
+      {label: 'Open Julia Startup File', command: 'julia:open-julia-startup-file'}
+      {label: 'Open Juno Startup File', command: 'julia:open-juno-startup-file'}
+      {label: 'Open Julia Home', command: 'julia:open-julia-home'}
+      {label: 'Open Package in New Window...', command: 'julia:open-package-in-new-window'}
 
       {type: 'separator'}
 

--- a/lib/package/toolbar.coffee
+++ b/lib/package/toolbar.coffee
@@ -7,46 +7,80 @@ module.exports =
     # Files & Folders
 
     @bar.addButton
-      icon: 'document'
+      icon: 'file-code'
+      iconset: 'fa'
+      tooltip: 'New Julia File'
       callback: ->
         atom.workspace.open().then (ed) ->
           ed.setGrammar(atom.grammars.grammarForScopeName('source.julia'))
-      tooltip: 'New Julia File'
-      iconset: 'ion'
 
     @bar.addButton
       icon: 'save'
-      callback: 'core:save'
-      tooltip: 'Save'
       iconset: 'fa'
+      tooltip: 'Save'
+      callback: 'core:save'
 
     @bar.addButton
-      icon: 'folder'
-      callback: 'application:open-file'
+      icon: 'folder-open'
+      iconset: 'fa'
       tooltip: 'Open File...'
-      iconset: 'ion'
+      callback: 'application:open-file'
+
+    # Julia process
 
     @bar.addSpacer()
 
     @bar.addButton
-      icon: 'planet'
+      icon: 'flame'
+      tooltip: 'Start Local Julia Process'
       callback: 'julia-client:start-remote-julia-process'
+
+    @bar.addButton
+      icon: 'globe'
       tooltip: 'Start Remote Julia Process'
+      callback: 'julia-client:start-remote-julia-process'
+
+    @bar.addButton
+      icon: 'pause'
       iconset: 'ion'
+      tooltip: 'Interrupt Julia'
+      callback: 'julia-client:interrupt-julia'
+
+    @bar.addButton
+      icon: 'stop'
+      iconset: 'ion'
+      tooltip: 'Stop Julia'
+      callback: 'julia-client:kill-julia'
+
+    # Evaluation
 
     @bar.addSpacer()
+
+    @bar.addButton
+      icon: 'zap'
+      tooltip: 'Run Block'
+      callback: 'julia-client:run-and-move'
+
+    @bar.addButton
+      icon: 'play'
+      iconset: 'ion'
+      tooltip: 'Run All'
+      callback: 'julia-client:run-all'
+
+    @bar.addButton
+      icon: 'format-float-none'
+      iconset: 'mdi'
+      tooltip: 'Format Code'
+      callback: 'julia-client:format-code'
 
     # Windows & Panes
+
+    @bar.addSpacer()
 
     @bar.addButton
       icon: 'terminal'
       callback: 'julia-client:open-console'
       tooltip: 'Show Console'
-
-    @bar.addButton
-      icon: 'graph'
-      callback: 'julia-client:open-plot-pane'
-      tooltip: 'Show Plots'
 
     @bar.addButton
       icon: 'book'
@@ -59,36 +93,14 @@ module.exports =
       tooltip: 'Show Documentation Browser'
 
     @bar.addButton
+      icon: 'graph'
+      callback: 'julia-client:open-plot-pane'
+      tooltip: 'Show Plots'
+
+    @bar.addButton
       icon: 'bug'
       callback: 'julia-debug:open-debugger-pane'
       tooltip: 'Show Debugger Pane'
-
-    @bar.addSpacer()
-
-    # Evaluation
-
-    @bar.addButton
-      icon: 'zap'
-      callback: 'julia-client:run-and-move'
-      tooltip: 'Run Block'
-
-    @bar.addButton
-      icon: 'play'
-      callback: 'julia-client:run-all'
-      tooltip: 'Run All'
-      iconset: 'ion'
-
-    @bar.addButton
-      icon: 'pause'
-      callback: 'julia-client:interrupt-julia'
-      tooltip: 'Interrupt Julia'
-      iconset: 'ion'
-
-    @bar.addButton
-      icon: 'stop'
-      callback: 'julia-client:kill-julia'
-      tooltip: 'Stop Julia'
-      iconset: 'ion'
 
   deactivate: ->
     @bar?.removeItems()

--- a/lib/runtime.coffee
+++ b/lib/runtime.coffee
@@ -11,6 +11,7 @@ module.exports =
   profiler:    require './runtime/profiler'
   linter:      require './runtime/linter'
   packages:    require './runtime/packages'
+  formatter:   require './runtime/formatter'
 
   activate: ->
     @modules.activate()

--- a/lib/runtime/formatter.js
+++ b/lib/runtime/formatter.js
@@ -13,29 +13,47 @@ export function formatCode () {
     formatEditor(editor)
   } else {
     selections.forEach((selection) => {
-      formatSelection(editor, selection)
+      formatEditorWithSelection(editor, selection)
     })
   }
 }
 
 function formatEditor (editor) {
+  const range = editor.getBuffer().getRange()
+  formatEditorTextInRange(editor, range, editor.getText())
+}
+
+function formatEditorWithSelection (editor, selection) {
+  const range = selection.getBufferRange()
+  formatEditorTextInRange (editor, range, selection.getText())
+}
+
+function formatEditorTextInRange (editor, range, text) {
+  const marker = markRange(editor, range)
   format({
-    text: editor.getText(),
+    text: text,
     // @NOTE: When DocumentFormat.jl comes to handle tabs as well as space-indents,
     //        branching via `getSoftTabs` API could be useful here.
     indent: editor.getTabLength()
   }).then(({ formattedtext }) => {
-    editor.setText(formattedtext)
+    if (marker.isValid()) {
+      editor.setTextInBufferRange(range, formattedtext)
+    } else {
+      atom.notifications.addError('Julia-Client: Format-Code', {
+        detail: 'Cancelled the formatting task since the code has been manually modified while formatting.',
+      })
+    }
+    marker.destroy()
   })
 }
 
-function formatSelection(editor, selection) {
-  const range = selection.getBufferRange()
-  format({
-    text: selection.getText(),
-    // @NOTE: Refer to above
-    indent: editor.getTabLength()
-  }).then(({ formattedtext }) => {
-    editor.setTextInBufferRange(range, formattedtext)
+function markRange(editor, range) {
+  const marker = editor.markBufferRange(range, {
+    invalidate: 'inside'
   })
+  editor.decorateMarker(marker, {
+    type: 'highlight',
+    class: 'ink-block'
+  })
+  return marker
 }

--- a/lib/runtime/formatter.js
+++ b/lib/runtime/formatter.js
@@ -1,0 +1,43 @@
+/** @babel */
+
+import { client } from '../connection'
+
+const { format } = client.import(['format'])
+
+
+// @TODO: Once DocumentFormat.jl comes to be able to handle options to specify indents,
+//        we can extract some information from the status-bar tile consumed by atom-indent-detective,
+//        or more safely, make atom-indent-detective provide the service and use it here ?
+
+export function formatCode () {
+  const editor = atom.workspace.getActiveTextEditor()
+  if (!editor) return
+
+  const selections = editor.getSelections()
+  if (selections.length === 1 && !selections[0].getText()) {
+    formatEditor(editor)
+  } else {
+    selections.forEach((selection) => {
+      formatSelection(editor, selection)
+    })
+  }
+}
+
+function formatEditor (editor) {
+  format({
+    text: editor.getText(),
+    // indent: INDENT // @TODO
+  }).then(({ formattedtext }) => {
+    editor.setText(formattedtext)
+  })
+}
+
+function formatSelection(editor, selection) {
+  const range = selection.getBufferRange()
+  format({
+    text: selection.getText(),
+    // indent: INDENT // @TODO
+  }).then(({ formattedtext }) => {
+    editor.setTextInBufferRange(range, formattedtext)
+  })
+}

--- a/lib/runtime/formatter.js
+++ b/lib/runtime/formatter.js
@@ -4,11 +4,6 @@ import { client } from '../connection'
 
 const { format } = client.import(['format'])
 
-
-// @TODO: Once DocumentFormat.jl comes to be able to handle options to specify indents,
-//        we can extract some information from the status-bar tile consumed by atom-indent-detective,
-//        or more safely, make atom-indent-detective provide the service and use it here ?
-
 export function formatCode () {
   const editor = atom.workspace.getActiveTextEditor()
   if (!editor) return
@@ -26,7 +21,9 @@ export function formatCode () {
 function formatEditor (editor) {
   format({
     text: editor.getText(),
-    // indent: INDENT // @TODO
+    // @NOTE: When DocumentFormat.jl comes to handle tabs as well as space-indents,
+    //        branching via `getSoftTabs` API could be useful here.
+    indent: editor.getTabLength()
   }).then(({ formattedtext }) => {
     editor.setText(formattedtext)
   })
@@ -36,7 +33,8 @@ function formatSelection(editor, selection) {
   const range = selection.getBufferRange()
   format({
     text: selection.getText(),
-    // indent: INDENT // @TODO
+    // @NOTE: Refer to above
+    indent: editor.getTabLength()
   }).then(({ formattedtext }) => {
     editor.setTextInBufferRange(range, formattedtext)
   })

--- a/lib/ui/layout.js
+++ b/lib/ui/layout.js
@@ -137,9 +137,9 @@ export function queryDefaultLayout () {
     ],
     description:
       `You can specify the panes to be opened and their _default location_ and _splitting rule_ in
-       **\`Settings -> Julia-Client > UI Options > Layout\`**.
-       \`Julia-Client:Restore-Default-Layout\` command will restore the layout at later point in time.
-       Use \`Julia-Client:Reset-Default-Layout-Settings\` command to reset the layout settings if it gets messed up.`,
+       **\`Settings -> Julia-Client -> UI Options -> Layout\`**.
+       \`Julia-Client: Restore-Default-Layout\` command will restore the layout at later point in time.
+       Use \`Julia-Client: Reset-Default-Layout-Settings\` command to reset the layout settings if it gets messed up.`,
     dismissable: true
   })
 }

--- a/menus/julia-client.cson
+++ b/menus/julia-client.cson
@@ -9,6 +9,7 @@
         {label: 'Select Block', command: 'julia-client:select-block'}
         {label: 'Go to Definition', command: 'julia-client:goto-symbol'}
         {label: 'Show Documentation', command: 'julia-client:show-documentation'}
+        {label: 'Format Code', command: 'julia-client:format-code'}
         {label: 'Toggle Breakpoint', command: 'julia-debug:toggle-breakpoint'}
         {label: 'Toggle Conditional Breakpoint', command: 'julia-debug:toggle-conditional-breakpoint'}
       ]


### PR DESCRIPTION
## Purpose

This PR adds `Julia-Client: Format-Code` command to format code in a currently opened editor.

The corresponding PR on Atom.jl side is: https://github.com/JunoLab/Atom.jl/pull/142

## Misc

This PR also clean up command/keymap registries. This is basically done in [this commit](https://github.com/JunoLab/atom-julia-client/commit/b1c5cf24db371d5521a9156b59941662f2641e05) so please refer to the commit message and the changes
