### PR TITLE
Fix build of Atom-beta in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ env:
 os:
   - linux
 
-dist: trusty
-
 matrix:
   include:
     # Sanity check for OS X
@@ -35,17 +33,21 @@ matrix:
 script:
   - julia ci/packages.jl
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
-  - bash build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 
+dist: xenial
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
     - g++-6
+    - build-essential
     - fakeroot
     - git
     - libsecret-1-dev
+    - libgconf2-4 # @TODO: Remove once Atom v1.39 comes to be stable
 
 notifications:
-    email: false
+  email: false


### PR DESCRIPTION
### Purpose 

Enables Travis build for `Atom>=1.39.0` by using Xenial image.

The build on OSX still keeps failing though, and I've not found the package example which succeeds to build the current
Atom version on OSX.

### Reference

https://github.com/atom/wrap-guide/blob/master/.travis.yml