### PR TITLE
Allow `MethodCompletion`s if whitespaces are preceding

### DIFF
--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -23,6 +23,7 @@ config =
                       a remote Julia process instead of a local one.'
         enum: ['Basic', 'Cycler', 'Remote']
         default: 'Cycler'
+        radio: true
         order: 1
       optimisationLevel:
         title: 'Optimisation Level'
@@ -30,6 +31,7 @@ config =
         type: 'integer'
         enum: [0, 1, 2, 3]
         default: 3
+        radio: true
         order: 2
       deprecationWarnings:
         title: 'Deprecation Warnings'

--- a/lib/runtime/completions.js
+++ b/lib/runtime/completions.js
@@ -11,15 +11,10 @@ import { Point, Range } from 'atom'
 import { client } from '../connection'
 import modules from './modules'
 
+const bracketScope = 'meta.bracket.julia'
 const completions = client.import('completions')
 
 class AutoCompleteProvider {
-  // @NOTE: This automatically respects emebedded Julia code and thus we don't need do something like
-  // ```js
-  // selector = atom.config.get('julia-client.juliaSyntaxScopes').map(selector => {
-  //   return `.${selector}`
-  // }).join(', ')
-  // ```
   selector = '.source.julia'
   disableForSelector = `.source.julia .comment`
   excludeLowerPriority = false
@@ -32,16 +27,19 @@ class AutoCompleteProvider {
 
     // Don't show suggestions if preceding char is a space (unless activate manually)
     if (!data.activatedManually) {
-      const point = data.bufferPosition
-      const { row, column } = point
+      const { editor, bufferPosition } = data
+      const { row, column } = bufferPosition
       if (column === 0) return []
-      const prevCharPoint = new Point(row, column - 1)
-      const range = new Range(prevCharPoint, point)
-      const text = data.editor.getTextInBufferRange(range)
-      if (text.match(/\s/)) return []
+      const prevCharPosition = new Point(row, column - 1)
+      const range = new Range(prevCharPosition, bufferPosition)
+      const text = editor.getTextInBufferRange(range)
+      // If the current position is in function call, show `REPLCompletions.MethodCompletion`s
+      // whatever whitespaces precede
+      const { scopes } = editor.scopeDescriptorForBufferPosition(bufferPosition)
+      if (!scopes.includes(bracketScope) && text.match(/\s/)) return []
     }
 
-    const suggestions = this.rawCompletions(data).then(({ completions, prefix, mod }) => {
+    const suggestions = this.rawCompletions(data).then(({ completions, prefix }) => {
       try {
         return this.processCompletions(completions, prefix)
       } catch (err) {
@@ -52,7 +50,7 @@ class AutoCompleteProvider {
   }
 
   rawCompletions (data) {
-    const { editor, bufferPosition: {row, column}, activatedManually } = data
+    const { editor, bufferPosition: { row, column }, activatedManually } = data
     const startPoint = new Point(row, 0)
     const endPoint = new Point(row, column)
     const lineRange = new Range(startPoint, endPoint)


### PR DESCRIPTION
I think `MethodCompletion`s are very useful and I want to make them available if the whitespaces are preceding the cursor.