### PR TITLE
migrate autocomplete stlye from ink

### DIFF
--- a/styles/julia-client.less
+++ b/styles/julia-client.less
@@ -97,6 +97,21 @@ atom-text-editor.editor {
   opacity: 0;
 }
 
+atom-text-editor.editor[data-grammar$="source julia"],
+atom-text-editor.editor[data-grammar$="source weave md"],
+atom-text-editor.editor[data-grammar$="source weave latex"] {
+  autocomplete-suggestion-list.select-list.popover-list {
+    .suggestion-description {
+      line-height: 1;
+      .suggestion-description-content {
+        overflow-y : hidden;
+        display    : inline;
+        white-space: normal; // can be useful to workaround https://github.com/atom/autocomplete-plus/issues/868
+      }
+    }
+  }
+}
+
 /* Hack datatip component style (overwrite user's global style) */
 // atom-ide-ui
 .datatip-marked {


### PR DESCRIPTION
it's better to keep it minimum where the global style override occurs.