### PR TITLE
ignore toplevel strings when finding code blocks

### DIFF
--- a/lib/misc/blocks.js
+++ b/lib/misc/blocks.js
@@ -4,20 +4,28 @@
 import { forLines } from './scopes'
 
 function getLine (ed, l) {
-  return ed.getTextInBufferRange([[l, 0], [l, Infinity]])
+  return {
+    scope: ed.scopeDescriptorForBufferPosition([l, 0]).scopes,
+    line: ed.getTextInBufferRange([[l, 0], [l, Infinity]])
+  }
 }
 
-function isBlank (l) {
-  return l.match(/^\s*(#.*)?$/)
+function isBlank ({line, scope}) {
+  for (let s of scope) {
+    if (/\bcomment\b/.test(s) || /\bstring\b/.test(s)) {
+      return true
+    }
+  }
+  return line.match(/^\s*(#.*)?$/)
 }
-function isEnd (l) {
-  return l.match(/^(end\b|\)|\]|\})/)
+function isEnd ({line, scope}) {
+  return line.match(/^(end\b|\)|\]|\})/)
 }
-function isCont (l) {
-  return l.match(/^(else|elseif|catch|finally)\b/)
+function isCont ({line, scope}) {
+  return line.match(/^(else|elseif|catch|finally)\b/)
 }
-function isStart (l) {
-  return !(l.match(/^\s/) || isBlank(l) || isEnd(l) || isCont(l))
+function isStart (lineInfo) {
+  return !(lineInfo.line.match(/^\s/) || isBlank(lineInfo) || isEnd(lineInfo) || isCont(lineInfo))
 }
 
 function walkBack(ed, row) {
@@ -30,28 +38,19 @@ function walkBack(ed, row) {
 function walkForward (ed, start) {
   let end
   let mark = (end = start)
-  let multiline = false
   while (mark < ed.getLastBufferRow()) {
     mark++
-    const l = getLine(ed, mark)
-    if (multiline) {
-      if (l.match(/=#/)) {
-        multiline = false
-      } else {
-        continue
-      }
-    }
-    if (isStart(l)) {
+    const lineInfo = getLine(ed, mark)
+
+    if (isStart(lineInfo)) {
       break
     }
-    if (isEnd(l)) {
+    if (isEnd(lineInfo)) {
       if (!(forLines(ed, start, mark-1).length === 0)) {
         end = mark
       }
-    } else if (!(isBlank(l) || isStart(l))) {
+    } else if (!(isBlank(lineInfo) || isStart(lineInfo))) {
       end = mark
-    } else if (l.match(/#=/) && !l.match(/=#/)) {
-      multiline = true
     }
   }
   return end


### PR DESCRIPTION
Fixes https://github.com/JunoLab/Juno.jl/issues/357 and simplifies the code a bit.

Not sure if I like relying on language-julia, but we basically control that too, so should be fine. #610 should make sure that everyone has that package installed.