### PR TITLE
Keybindings for all debugger commands

### DIFF
--- a/keymaps/julia-client.cson.cmd
+++ b/keymaps/julia-client.cson.cmd
@@ -8,7 +8,13 @@ Any global commands should either be non-default or, ideally, prefixed with `C-J
 ## Common
 # Debug operations
 'atom-text-editor[data-grammar="source julia"]':
+  'shift-f5': 'julia-debug:stop-debugging'
+  'f8': 'julia-debug:continue'
+  'shift-f8': 'julia-debug:step-to-selected-line'
+  'f9': 'julia-debug:toggle-breakpoint'
+  'shift-f9': 'julia-debug:toggle-conditional-breakpoint'
   'f10': 'julia-debug:step-to-next-expression'
+  'shift-f10': 'julia-debug:step-to-next-line'
   'f11': 'julia-debug:step-into-function'
   'shift-f11': 'julia-debug:finish-function'
 
@@ -27,8 +33,6 @@ Any global commands should either be non-default or, ideally, prefixed with `C-J
   'cmd-j cmd-d': 'julia-client:show-documentation'
   'cmd-j cmd-m': 'julia-client:set-working-module'
   'cmd-j cmd-f': 'julia-client:format-code'
-  'ctrl-x': 'julia-debug:toggle-breakpoint'
-  'ctrl-shift-x': 'julia-debug:toggle-conditional-breakpoint'
 
 # Julia REPL
 '.platform-darwin .julia-terminal':

--- a/keymaps/julia-client.cson.ctrl
+++ b/keymaps/julia-client.cson.ctrl
@@ -8,7 +8,13 @@ Any global commands should either be non-default or, ideally, prefixed with `C-J
 ## Common
 # Debug operations
 'atom-text-editor[data-grammar="source julia"]':
+  'shift-f5': 'julia-debug:stop-debugging'
+  'f8': 'julia-debug:continue'
+  'shift-f8': 'julia-debug:step-to-selected-line'
+  'f9': 'julia-debug:toggle-breakpoint'
+  'shift-f9': 'julia-debug:toggle-conditional-breakpoint'
   'f10': 'julia-debug:step-to-next-expression'
+  'shift-f10': 'julia-debug:step-to-next-line'
   'f11': 'julia-debug:step-into-function'
   'shift-f11': 'julia-debug:finish-function'
 
@@ -28,8 +34,6 @@ Any global commands should either be non-default or, ideally, prefixed with `C-J
   'ctrl-j ctrl-m': 'julia-client:set-working-module'
   'ctrl-j ctrl-f': 'julia-client:format-code'
   'ctrl-shift-c': 'julia-client:interrupt-julia'
-  'alt-x': 'julia-debug:toggle-breakpoint'
-  'alt-shift-x': 'julia-debug:toggle-conditional-breakpoint'
 
 # Julia REPL
 '.platform-win32 .julia-terminal,


### PR DESCRIPTION
### Existing bindings:
```
f10 step-to-next-expression
f11 step-into-function
shift+f11 finish-function
alt-x toggle-breakpoint
alt+shift+x toggle-conditional-breakpoint
```

### Proposed bindings:
```
f5 start-debugging
shift-f5 stop-debugging
f8 continue
shift-f8 step-to-selected-line
f9 toggle-breakpoint
shift-f9 toggle-conditional-breakpoint
f10 step-to-next-expression
shift-f10 step-to-next-line
f11 step-into-function
shift-f11 finish-function
```

The proposed bindings are closer to what users might expect from other IDEs. Using the [default VSCode bindings](https://code.visualstudio.com/docs/getstarted/keybindings#_debug) for inspiration.
### Differences from the VSCode defaults:
```
continue: change, f5 => f8
step-to-selected-line: new, shift-f8
toggle-conditional-breakpoint: new, shift-f9
step-to-next-expression: new, f10
step-to-next-line: change, f10 => shift-f10
```

### Unbound commands:
* `clear-all-breakpoints`
    * Could use a modified f9 command, but I'm concerned that users might confuse this for the toggle-conditional-breakpoint binding, and it would be really annoying to accidentally lose all your breakpoints.
* `open-debugger-pane`
    * Doesn't seem like this needs a hotkey.

### Changes required:

#### Replacements:
```
toggle-breakpoint: alt-x => f9
toggle-conditional-breakpoint: alt-shift-x => shift-f9
```
#### Additions:
```
f5 start-debugging (see notes on this "new command" below)
shift-f5 stop-debugging
f8 continue
shift-f8 step-to-selected-line
shift-f10 step-to-next-line
```
#### New command:
* `start-debugging`.
    * This is not very important, and not implemented in this change. One possibility is to remember the last `Juno.@enter` or `Juno.@run` command.

### Note on line vs expression stepping:
Debating whether to use f10 for step-to-next-line and shift-f10 for step-to-next-expression or the other way around.
Motivation for line as f10 is to match other IDEs, even though VSCode doesn't have expression stepping.
Motivation for expression as f10 is to match the pattern established by f11 step-into-function and shift-f11 finish-function, where modifying with shift takes a bigger step. This is also one-fewer Juno binding change.

```
# keymap for testing these changes without incorporating pull request
# ~/.atom/keymap.cson
'atom-text-editor[data-grammar="source julia"]':
  #'f5': 'julia-debug:start-debugging' # Todo: add start-debugging command
  'shift-f5': 'julia-debug:stop-debugging'
  'f8': 'julia-debug:continue'
  'shift-f8': 'julia-debug:step-to-selected-line'
  'f9': 'julia-debug:toggle-breakpoint' # changed from alt-x
  'shift-f9': 'julia-debug:toggle-conditional-breakpoint' # changed from alt-shift-x
  #'f10': 'julia-debug:step-to-next-expression' # existing
  'shift-f10': 'julia-debug:step-to-next-line'
  #'f11': 'julia-debug:step-into-function' # existing
  #'shift-f11': 'julia-debug:finish-function' # existing
```