### PR TITLE
exclude default completion provider

### DIFF
--- a/lib/runtime/completions.js
+++ b/lib/runtime/completions.js
@@ -18,7 +18,7 @@ const completions = client.import('completions')
 class AutoCompleteProvider {
   selector = '.source.julia'
   disableForSelector = `.source.julia .comment`
-  excludeLowerPriority = false
+  excludeLowerPriority = true
   inclusionPriority = 3
   suggestionPriority = atom.config.get('julia-client.juliaOptions.autoCompletionSuggestionPriority')
   filterSuggestions = false

--- a/lib/runtime/completions.js
+++ b/lib/runtime/completions.js
@@ -19,7 +19,7 @@ class AutoCompleteProvider {
   selector = '.source.julia'
   disableForSelector = `.source.julia .comment`
   excludeLowerPriority = true
-  inclusionPriority = 3
+  inclusionPriority = 1
   suggestionPriority = atom.config.get('julia-client.juliaOptions.autoCompletionSuggestionPriority')
   filterSuggestions = false
 


### PR DESCRIPTION
Works pretty well for me -- snippets are still there (they have `inclusionPriority: 1`), as are latex-completions (with `inclusionPriority: 5`).

The one thing we need to think about is removing the `disableForSelector = '.source.julia .comment'` line, because that means you still end up with the default completions in comments. Thoughts?