### PR TITLE
Update toolbar for missing icons

### DIFF
--- a/lib/package/toolbar.coffee
+++ b/lib/package/toolbar.coffee
@@ -37,18 +37,18 @@ module.exports =
 
     @bar.addButton
       iconset: 'ion'
-      icon: 'planet'
+      icon: 'md-planet'
       tooltip: 'Start Remote Julia Process'
       callback: 'julia-client:start-remote-julia-process'
 
     @bar.addButton
-      icon: 'pause'
+      icon: 'md-pause'
       iconset: 'ion'
       tooltip: 'Interrupt Julia'
       callback: 'julia-client:interrupt-julia'
 
     @bar.addButton
-      icon: 'stop'
+      icon: 'md-square'
       iconset: 'ion'
       tooltip: 'Stop Julia'
       callback: 'julia-client:kill-julia'
@@ -63,7 +63,7 @@ module.exports =
       callback: 'julia-client:run-and-move'
 
     @bar.addButton
-      icon: 'play'
+      icon: 'md-play'
       iconset: 'ion'
       tooltip: 'Run All'
       callback: 'julia-client:run-all'


### PR DESCRIPTION
Some icons have gone missing following the most recent update to the toolbar package because the ion icons now need the `md-` prefix; also, `stop` is now called `square`.

see, e.g.

https://github.com/suda/tool-bar/releases/tag/v1.2.0

https://github.com/suda/tool-bar/issues/264