### PR TITLE
add an option to always show errors in REPL when using inline evaluation

### DIFF
--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -135,43 +135,49 @@ config =
         type: 'boolean'
         default: true
         description: 'When evaluating a script, show errors in a notification as
-                      well as in the console.'
+                      well as in the REPL.'
         order: 4
+      errorInRepl:
+        title: 'Show Errors in REPL (Inline Evaluation)'
+        type: 'boolean'
+        default: false
+        description: 'If enabled, Juno always shows errors in the REPL when using inline evaluation.'
+        order: 5
       enableMenu:
         title: 'Enable Menu'
         type: 'boolean'
         default: false
         description: 'Show a Julia menu in the menu bar (requires restart).'
-        order: 5
+        order: 6
       enableToolBar:
         title: 'Enable Toolbar'
         type: 'boolean'
         default: false
         description: 'Show Julia icons in the tool bar (requires restart).'
-        order: 6
+        order: 7
       usePlotPane:
         title: 'Enable Plot Pane'
         type: 'boolean'
         description: 'Show plots in Atom.'
         default: true
-        order: 7
+        order: 8
       openNewEditorWhenDebugging:
         title: 'Open New Editor When Debugging'
         type: 'boolean'
         default: false
         description: 'Opens a new editor tab when stepping into a new file instead
                       of reusing the current one (requires restart).'
-        order: 8
+        order: 9
       cellDelimiter:
         title: 'Cell Delimiter'
         type: 'array'
         default: ['##', '#---', '#%%', '# %%']
         description: 'Regular expressions for determining cell delimiters.'
-        order: 9
+        order: 10
       layouts:
         title: 'Layout Options'
         type: 'object'
-        order: 10
+        order: 11
         collapsed: true
         properties:
           console:

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -115,6 +115,11 @@ config =
           {value:'console', description:'Display results in the console'}
         ]
         order: 1
+      scrollToResult:
+        title: 'Scroll to Inline Results'
+        type: 'boolean'
+        default: false
+        order: 2
       docsDisplayMode:
         title: 'Documentation Display Mode'
         type: 'string'
@@ -123,13 +128,7 @@ config =
           {value: 'inline', description: 'Show documentation in the editor'}
           {value: 'pane', description: 'Show documentation in the documentation pane'}
         ]
-        order: 2
-      # notifications:
-      #   title: 'Notifications'
-      #   type: 'boolean'
-      #   default: true
-      #   description: 'Enable notifications for evaluation.'
-      #   order: 3
+        order: 3
       errorNotifications:
         title: 'Error Notifications'
         type: 'boolean'

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -39,7 +39,7 @@ module.exports =
       else
         r = null
         setTimeout (=> r ?= new @ink.Result editor, [start, end], {type: rtype, scope: 'julia'}), 0.1
-        evaluate({text, line: line+1, mod, path: edpath})
+        evaluate({text, line: line+1, mod, path: edpath, errorInRepl: atom.config.get('julia-client.uiOptions.errorInRepl')})
           .catch -> r?.destroy()
           .then (result) =>
             if not result?


### PR DESCRIPTION
Needs https://github.com/JunoLab/Atom.jl/pull/195 to actually do something.

Fixes https://github.com/JunoLab/Juno.jl/issues/378 and https://github.com/JunoLab/Juno.jl/issues/381.