### PR TITLE
follow646

### DIFF
--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -157,26 +157,32 @@ config =
       usePlotPane:
         title: 'Enable Plot Pane'
         type: 'boolean'
-        description: 'Show plots in Atom.'
         default: true
+        description: 'Show plots in Atom.'
         order: 8
+      maxNumberPlots:
+        title: 'Maximum Number of Plots in History'
+        type: 'number'
+        default: 50
+        description: 'Increasing this number may lead to high memory consumption and poor performance.'
+        order: 9
       openNewEditorWhenDebugging:
         title: 'Open New Editor When Debugging'
         type: 'boolean'
         default: false
         description: 'Opens a new editor tab when stepping into a new file instead
                       of reusing the current one (requires restart).'
-        order: 9
+        order: 10
       cellDelimiter:
         title: 'Cell Delimiter'
         type: 'array'
         default: ['##', '#---', '#%%', '# %%']
         description: 'Regular expressions for determining cell delimiters.'
-        order: 10
+        order: 11
       layouts:
         title: 'Layout Options'
         type: 'object'
-        order: 11
+        order: 12
         collapsed: true
         properties:
           console:
@@ -410,12 +416,6 @@ config =
             type: 'boolean'
             default: true
             order: 11
-      maxNumberPlots:
-        title: 'Maximum Number of Plots in History'
-        type: 'number'
-        description: 'Increasing this number may lead to high memory consumption and poor performance.'
-        default: 50
-        order: 12
   consoleOptions:
     type: 'object'
     title: 'Terminal Options'

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -28,14 +28,14 @@ module.exports =
 
   eval: ({move, cell}={}) ->
     {editor, mod, edpath} = @_currentContext()
-    selector = if cell? then cells else blocks
+    codeSelector = if cell? then cells else blocks
     # global options
     resultsDisplayMode = atom.config.get('julia-client.uiOptions.resultsDisplayMode')
     errorInRepl = atom.config.get('julia-client.uiOptions.errorInRepl')
     scrollToResult = atom.config.get('julia-client.uiOptions.scrollToResult')
 
-    Promise.all selector.get(editor).map ({range, line, text, selection}) =>
-      selector.moveNext editor, selection, range if move
+    Promise.all codeSelector.get(editor).map ({range, line, text, selection}) =>
+      codeSelector.moveNext editor, selection, range if move
       [[start], [end]] = range
       @ink.highlight editor, start, end
       rtype = if cell? then "block" else resultsDisplayMode

--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -127,8 +127,7 @@ module.exports =
     if dirEl
       pathEl = dirEl.querySelector('[data-path]')
       if pathEl
-        path = pathEl.dataset.path
-        return path
+        return pathEl.dataset.path
     # invoked from normal command usage
     file = client.editorPath(atom.workspace.getCenter().getActiveTextEditor())
     if file

--- a/menus/julia-client.cson
+++ b/menus/julia-client.cson
@@ -1,7 +1,6 @@
 'context-menu':
   'atom-text-editor[data-grammar="source julia"]': [
     {type: 'separator'}
-
     {
       label: 'Juno',
       submenu: [
@@ -16,10 +15,17 @@
         {label: 'Toggle Conditional Breakpoint', command: 'julia-debug:toggle-conditional-breakpoint'}
       ]
     }
-
     {type: 'separator'}
   ]
+
   '.tree-view li.directory': [
-    { label: 'Juno: Work in Folder', command: 'julia-client:work-in-current-folder' }
-    { label: 'Juno: Activate Project', command: 'julia-client:activate-current-folder' }
+    {type: 'separator'}
+    {
+      label: 'Juno',
+      submenu: [
+        { label: 'Work in Folder', command: 'julia-client:work-in-current-folder' }
+        { label: 'Activate Project', command: 'julia-client:activate-current-folder' }
+      ]
+    }
+    {type: 'separator'}
   ]


### PR DESCRIPTION
`currentDir` can now error when invoked _not_ from tree-view context menu.
I also found `cdProject` can error as well.

All the evil was the variable hoisting.