### PR TITLE
misc updates around https://github.com/JunoLab/Atom.jl/pull/215

### DIFF
--- a/lib/runtime/goto.js
+++ b/lib/runtime/goto.js
@@ -13,7 +13,8 @@ import { getLocalContext } from '../misc/blocks'
 const {
   gotosymbol: gotoSymbol,
   regeneratesymbols: regenerateSymbols,
-} = client.import(['gotosymbol', 'regeneratesymbols'])
+  clearsymbols: clearSymbols,
+} = client.import(['gotosymbol', 'regeneratesymbols', 'clearsymbols'])
 
 const includeRegex = /(include|include_dependency)\(".+\.jl"\)/
 const filePathRegex = /".+\.jl"/
@@ -23,8 +24,11 @@ class Goto {
     this.ink = ink
     this.subscriptions = new CompositeDisposable()
     this.subscriptions.add(
-      atom.commands.add('atom-workspace', 'julia-client:regenerate-symbol-cache', () => {
+      atom.commands.add('atom-workspace', 'julia-client:regenerate-symbols-cache', () => {
         regenerateSymbols()
+      }),
+      atom.commands.add('atom-workspace', 'julia-client:clear-symbols-cache', () => {
+        clearSymbols()
       })
     )
   }

--- a/lib/runtime/goto.js
+++ b/lib/runtime/goto.js
@@ -85,7 +85,7 @@ class Goto {
 
     gotoSymbol({
       word,
-      path: editor.getPath(),
+      path: editor.getPath() || 'untitled-' + editor.getBuffer().getId(),
       // local context
       column: column + 1,
       row: row + 1,
@@ -142,7 +142,7 @@ class Goto {
       return new Promise((resolve, reject) => {
         gotoSymbol({
           word,
-          path: textEditor.getPath(),
+          path: textEditor.getPath() || 'untitled-' + textEditor.getBuffer().getId(),
           // local context
           column: column + 1,
           row: row + 1,

--- a/lib/runtime/outline.js
+++ b/lib/runtime/outline.js
@@ -79,7 +79,7 @@ function updateEditor (editor, options = {
   const text = editor.getText()
   const currentModule = modules.current()
   const mod = currentModule ? currentModule : 'Main'
-  const path = editor.getPath()
+  const path = editor.getPath() || 'untitled-' + editor.getBuffer().getId()
   return updateeditor({
     text,
     mod,


### PR DESCRIPTION
Helps https://github.com/JunoLab/Atom.jl/pull/215:
- add goto supports for unsaved editors
- add `clear-symbols-cache` command

***

Requires https://github.com/JunoLab/Atom.jl/pull/215.