### PR TITLE
initialize `lastEditor` and `lastTerminal` after package activation

### DIFF
--- a/lib/ui/focusutils.js
+++ b/lib/ui/focusutils.js
@@ -45,14 +45,25 @@ class FocusHistory {
 
 export function activate (ink) {
   subs = new CompositeDisposable()
-  
-  subs.add(atom.workspace.onDidStopChangingActivePaneItem((item) => {
-    if (item instanceof TextEditor) {
-      lastEditor = item
-    } else if (item instanceof ink.InkTerminal) {
-      lastTerminal = item
-    }
-  }))
+
+  subs.add(
+    atom.workspace.onDidStopChangingActivePaneItem(item => {
+      if (item instanceof TextEditor) {
+        lastEditor = item
+      } else if (item instanceof ink.InkTerminal) {
+        lastTerminal = item
+      }
+    },
+    atom.packages.onDidActivateInitialPackages(() => {
+      lastEditor = atom.workspace.getActiveTextEditor()
+      atom.workspace.getPanes().forEach(pane => {
+        const item = pane.getActiveItem()
+        if (item instanceof ink.InkTerminal) {
+          lastTerminal = item
+        }
+      })
+    })
+  ))
 
   const history = new FocusHistory(30)
   ink.Opener.onDidOpen(({newLocation, oldLocation}) => {


### PR DESCRIPTION
Then we can invoke `focus-last-editor` and `focus-last-terminal` commands from the very beginning.