### PR TITLE
open terminal from a text editor's directory

### DIFF
--- a/lib/package/commands.coffee
+++ b/lib/package/commands.coffee
@@ -124,7 +124,7 @@ module.exports =
       'julia-client:work-in-current-folder': (ev) ->
         requireClient 'change working folder', ->
           juno.runtime.evaluation.cdHere(ev.target)
-      'julia-client:activate-current-folder': (ev) ->
+      'julia-client:activate-environment-in-current-folder': (ev) ->
         requireClient 'activate an environment', ->
           juno.runtime.evaluation.activateProject(ev.target)
       'julia-client:activate-default-environment': (ev) ->

--- a/lib/package/menu.coffee
+++ b/lib/package/menu.coffee
@@ -44,7 +44,7 @@ module.exports =
       {
         label: 'Environment',
         submenu: [
-          {label: 'Current File\'s Folder', command: 'julia-client:activate-current-folder'}
+          {label: 'Environment in Current File\'s Folder', command: 'julia-client:activate-environment-in-current-folder'}
           {label: 'Default Environment', command: 'julia-client:activate-default-environment'}
         ]
       }

--- a/lib/package/menu.coffee
+++ b/lib/package/menu.coffee
@@ -36,9 +36,16 @@ module.exports =
         label: 'Working Directory'
         submenu: [
           {label: 'Current File\'s Folder', command: 'julia-client:work-in-current-folder'}
-          {label: 'Current Project\'s Folder', command: 'julia-client:work-in-project-folder'}
+          {label: 'Current Project\'s Folders', command: 'julia-client:work-in-project-folder'}
           {label: 'Home Folder', command: 'julia-client:work-in-home-folder'}
           {label: 'Select...', command: 'julia-client:select-working-folder'}
+        ]
+      }
+      {
+        label: 'Active Project',
+        submenu: [
+          {label: 'Current File\'s Folder', command: 'julia-client:activate-current-folder'}
+          {label: 'Default Environment', command: 'julia-client:activate-default-environment'}
         ]
       }
       {label: 'Select Working Module', command: 'julia-client:select-working-module'}
@@ -66,7 +73,13 @@ module.exports =
 
       {type: 'separator'}
 
-      {label: 'New Terminal', command: 'julia-client:new-terminal'}
+      {
+        label: 'New Terminal'
+        submenu: [
+          {label: 'Current File\'s Folder', command: 'julia-client:new-terminal-from-current-folder'}
+          {label: 'Current Project\'s Folders', command: 'julia-client:new-terminal'}
+        ]
+      }
       {label: 'New Remote Terminal', command: 'julia-client:new-remote-terminal'}
 
       {type: 'separator'}

--- a/lib/package/menu.coffee
+++ b/lib/package/menu.coffee
@@ -36,7 +36,7 @@ module.exports =
         label: 'Working Directory'
         submenu: [
           {label: 'Current File\'s Folder', command: 'julia-client:work-in-current-folder'}
-          {label: 'Current Project\'s Folders', command: 'julia-client:work-in-project-folder'}
+          {label: 'Select Project Folder', command: 'julia-client:work-in-project-folder'}
           {label: 'Home Folder', command: 'julia-client:work-in-home-folder'}
           {label: 'Select...', command: 'julia-client:select-working-folder'}
         ]

--- a/lib/package/menu.coffee
+++ b/lib/package/menu.coffee
@@ -77,7 +77,7 @@ module.exports =
         label: 'New Terminal'
         submenu: [
           {label: 'Current File\'s Folder', command: 'julia-client:new-terminal-from-current-folder'}
-          {label: 'Current Project\'s Folders', command: 'julia-client:new-terminal'}
+          {label: 'Select Project Folder', command: 'julia-client:new-terminal'}
         ]
       }
       {label: 'New Remote Terminal', command: 'julia-client:new-remote-terminal'}

--- a/lib/package/menu.coffee
+++ b/lib/package/menu.coffee
@@ -42,7 +42,7 @@ module.exports =
         ]
       }
       {
-        label: 'Active Project',
+        label: 'Environment',
         submenu: [
           {label: 'Current File\'s Folder', command: 'julia-client:activate-current-folder'}
           {label: 'Default Environment', command: 'julia-client:activate-default-environment'}

--- a/lib/runtime/console.js
+++ b/lib/runtime/console.js
@@ -35,20 +35,21 @@ export function activate (_ink) {
 
   process.env['TERM'] = 'xterm-256color'
 
-  subs.add(atom.config.observe('julia-client.consoleOptions.whitelistedKeybindingsREPL', (kbds) => {
-    whitelistedKeybindingsREPL = kbds.map(s => s.toLowerCase())
-  }))
-  subs.add(atom.config.observe('julia-client.consoleOptions.whitelistedKeybindingsTerminal', (kbds) => {
-    whitelistedKeybindingsTerminal = kbds.map(s => s.toLowerCase())
-  }))
-  subs.add(atom.config.observe('julia-client.consoleOptions.cursorStyle', updateTerminalSettings))
-  subs.add(atom.config.observe('julia-client.consoleOptions.maximumConsoleSize', updateTerminalSettings))
-  subs.add(atom.config.observe('julia-client.consoleOptions.macOptionIsMeta', updateTerminalSettings))
-  subs.add(atom.config.observe('julia-client.consoleOptions.rendererType', updateTerminalSettings))
-  subs.add(atom.config.observe('julia-client.consoleOptions.cursorBlink', updateTerminalSettings))
+  subs.add(
+    atom.config.observe('julia-client.consoleOptions.whitelistedKeybindingsREPL', (kbds) => {
+      whitelistedKeybindingsREPL = kbds.map(s => s.toLowerCase())
+    }),
+    atom.config.observe('julia-client.consoleOptions.whitelistedKeybindingsTerminal', (kbds) => {
+      whitelistedKeybindingsTerminal = kbds.map(s => s.toLowerCase())
+    }),
+    atom.config.observe('julia-client.consoleOptions.cursorStyle', updateTerminalSettings),
+    atom.config.observe('julia-client.consoleOptions.maximumConsoleSize', updateTerminalSettings),
+    atom.config.observe('julia-client.consoleOptions.macOptionIsMeta', updateTerminalSettings),
+    atom.config.observe('julia-client.consoleOptions.rendererType', updateTerminalSettings),
+    atom.config.observe('julia-client.consoleOptions.cursorBlink', updateTerminalSettings)
+  )
 
   terminal = ink.InkTerminal.fromId('julia-terminal', terminalOptions())
-
   terminal.setTitle('REPL', true)
   terminal.class = 'julia-terminal'
 
@@ -109,8 +110,8 @@ export function activate (_ink) {
     if (promptObserver) promptObserver.dispose()
   })
 
-  // repl commands
   subs.add(
+    // repl commands
     atom.commands.add('atom-workspace', {
       'julia-client:open-REPL': () => {
         open().then(() => terminal.show())
@@ -125,23 +126,22 @@ export function activate (_ink) {
           atom.commands.dispatch(terminal.view, 'julia-client:interrupt-julia')
         }
       }
+    }),
+    // terminal commands
+    atom.commands.add('atom-workspace', {
+      'julia-client:new-terminal': () => {
+        newTerminal()
+      },
+      'julia-client:new-terminal-from-current-folder': ev => {
+        const dir = evaluation.currentDir(ev.target)
+        if (!dir) return
+        newTerminal(dir)
+      },
+      'julia-client:new-remote-terminal': () => {
+        newRemoteTerminal()
+      }
     })
   )
-
-  // terminal commands
-  subs.add(atom.commands.add('atom-workspace', {
-    'julia-client:new-terminal': () => {
-      newTerminal()
-    },
-    'julia-client:new-terminal-from-current-folder': ev => {
-      const dir = evaluation.currentDir(ev.target)
-      if (!dir) return
-      newTerminal(dir)
-    },
-    'julia-client:new-remote-terminal': () => {
-      newRemoteTerminal()
-    }
-  }))
 
   // handle deserialized terminals
   forEachPane(item => {
@@ -351,11 +351,7 @@ export function deactivate () {
     item.detach()
     item.close()
   }, /terminal\-remote\-julia\-\d+/)
-  if (terminal) {
-    terminal.detach()
-  }
-  if (subs) {
-    subs.dispose()
-  }
+  if (terminal) terminal.detach()
+  if (subs) subs.dispose()
   subs = null
 }

--- a/lib/runtime/console.js
+++ b/lib/runtime/console.js
@@ -4,6 +4,7 @@ import { client } from '../connection'
 import { customEnv } from '../connection/process/basic'
 import { CompositeDisposable } from 'atom'
 import { paths } from '../misc'
+import evaluation from './evaluation'
 import modules from './modules'
 import * as pty from 'node-pty-prebuilt-multiarch'
 import { debounce } from 'underscore-plus'
@@ -108,23 +109,39 @@ export function activate (_ink) {
     if (promptObserver) promptObserver.dispose()
   })
 
-  subs.add(atom.commands.add('atom-workspace', 'julia-client:open-REPL', () => {
-    open().then(() => terminal.show())
-  }))
+  // repl commands
+  subs.add(
+    atom.commands.add('atom-workspace', {
+      'julia-client:open-REPL': () => {
+        open().then(() => terminal.show())
+      },
+      'julia-client:clear-REPL': () => {
+        terminal.clear()
+      },
+    }),
+    atom.commands.add('.julia-terminal', {
+      'julia-client:copy-or-interrupt': () => {
+        if (!terminal.copySelection()) {
+          atom.commands.dispatch(terminal.view, 'julia-client:interrupt-julia')
+        }
+      }
+    })
+  )
 
-  subs.add(atom.commands.add('atom-workspace', 'julia-client:clear-REPL', () => {
-    terminal.clear()
-  }))
-
-  subs.add(atom.commands.add('.julia-terminal', 'julia-client:copy-or-interrupt', () => {
-    if (!terminal.copySelection()) {
-      atom.commands.dispatch(terminal.view, 'julia-client:interrupt-julia')
+  // terminal commands
+  subs.add(atom.commands.add('atom-workspace', {
+    'julia-client:new-terminal': () => {
+      newTerminal()
+    },
+    'julia-client:new-terminal-from-current-folder': ev => {
+      const dir = evaluation.currentDir(ev.target)
+      if (!dir) return
+      newTerminal(dir)
+    },
+    'julia-client:new-remote-terminal': () => {
+      newRemoteTerminal()
     }
   }))
-
-  subs.add(atom.commands.add('atom-workspace', 'julia-client:new-terminal', newTerminal))
-
-  subs.add(atom.commands.add('atom-workspace', 'julia-client:new-remote-terminal', newRemoteTerminal))
 
   // handle deserialized terminals
   forEachPane(item => {
@@ -149,11 +166,11 @@ export function close () {
   return terminal.close()
 }
 
-function newTerminal () {
+function newTerminal (cwd) {
   const term = ink.InkTerminal.fromId(`terminal-julia-${Math.floor(Math.random()*10000000)}`, terminalOptions())
   term.attachCustomKeyEventHandler((e) => handleKeybinding(e, term))
   addLinkHandler(term.terminal)
-  shellPty().then(({pty, cwd}) => {
+  shellPty(cwd).then(({pty, cwd}) => {
     term.attach(pty, true, cwd)
     term.setDefaultLocation(atom.config.get('julia-client.uiOptions.layouts.terminal.defaultLocation'))
     term.open({
@@ -294,17 +311,8 @@ function shellPty (cwd) {
     if (cwd) {
       pr = new Promise((resolve) => resolve(cwd))
     } else {
-      const paths = new Set()
-      // add project paths
-      atom.project.getPaths().forEach(p => {
-        paths.add(p)
-      })
-      // add active text editor's directory
-      atom.workspace.getTextEditors().forEach(editor => {
-        const p = editor.getDirectoryPath()
-        if (p) paths.add(p)
-      })
-      pr = selector.show(Array.from(paths), {
+      // show project paths
+      pr = selector.show(atom.project.getPaths(), {
         emptyMessage: 'Enter a custom path above.',
         allowCustom: true
       })
@@ -318,7 +326,7 @@ function shellPty (cwd) {
           })
           cwd = paths.home()
         }
-        env = customEnv()
+        const env = customEnv()
         resolve({
           pty: pty.fork(atom.config.get("julia-client.consoleOptions.shell"), [], {
             cols: 100,

--- a/lib/runtime/console.js
+++ b/lib/runtime/console.js
@@ -294,8 +294,17 @@ function shellPty (cwd) {
     if (cwd) {
       pr = new Promise((resolve) => resolve(cwd))
     } else {
-      const projectPaths = atom.workspace.project.getDirectories().map((el) => el.path)
-      pr = selector.show(projectPaths, {
+      const paths = new Set()
+      // add project paths
+      atom.project.getPaths().forEach(p => {
+        paths.add(p)
+      })
+      // add active text editor's directory
+      atom.workspace.getTextEditors().forEach(editor => {
+        const p = editor.getDirectoryPath()
+        if (p) paths.add(p)
+      })
+      pr = selector.show(Array.from(paths), {
         emptyMessage: 'Enter a custom path above.',
         allowCustom: true
       })

--- a/menus/julia-client.cson
+++ b/menus/julia-client.cson
@@ -24,8 +24,8 @@
       label: 'Juno',
       submenu: [
         { label: 'Work in Folder', command: 'julia-client:work-in-current-folder' }
-        { label: 'Activate Project', command: 'julia-client:activate-current-folder' }
-        { label: 'New Terminal', command: 'julia-client:new-terminal-from-current-folder'}
+        { label: 'Activate Environment in Folder', command: 'julia-client:activate-environment-in-current-folder' }
+        { label: 'New Terminal from Folder', command: 'julia-client:new-terminal-from-current-folder'}
       ]
     }
     {type: 'separator'}

--- a/menus/julia-client.cson
+++ b/menus/julia-client.cson
@@ -25,6 +25,7 @@
       submenu: [
         { label: 'Work in Folder', command: 'julia-client:work-in-current-folder' }
         { label: 'Activate Project', command: 'julia-client:activate-current-folder' }
+        { label: 'New Terminal', command: 'julia-client:new-terminal-from-current-folder'}
       ]
     }
     {type: 'separator'}


### PR DESCRIPTION
I often want this when editing files outside of a current project.

Or maybe creating commands like `julia-client: new-(remote-)terminal-from-active-directory` (which will just start a terminal within a currently active editor's directory) is more preferable ?