### PR TITLE
work in folder and activate project commands with focusing on tree-view

### DIFF
--- a/lib/runtime/evaluation.coffee
+++ b/lib/runtime/evaluation.coffee
@@ -129,6 +129,10 @@ module.exports =
   currentDir: (el) ->
     # invoked from tree-view context menu
     dirEl = el.closest('.directory')
+    # invoked from command with focusing on tree-view
+    if not dirEl
+      activeEl = el.querySelector('.tree-view .selected')
+      dirEl = activeEl.closest('.directory') if activeEl
     if dirEl
       pathEl = dirEl.querySelector('[data-path]')
       if pathEl


### PR DESCRIPTION
for keyboard shortcut people like me :)

***

Now those behaviours are a bit implicit -- maybe separating those tree-view-related behaviours into new commands like `work-in-active-folder-in-tree-view` and `activate-environment-in-active-folder-in-tree-view` and register them `.tree-view` selector would be more explicit.
