### PR TITLE
fix subtle errors in cell highlighting

### DIFF
--- a/lib/ui.coffee
+++ b/lib/ui.coffee
@@ -19,6 +19,8 @@ module.exports =
         @cellhighlighter.activate()
       else
         @cellhighlighter.deactivate()
+    @subs.add new Disposable =>
+      @cellhighlighter.deactivate()
 
     @subs.add @client.onAttached =>
       @notifications.show("Client Connected")
@@ -27,7 +29,6 @@ module.exports =
 
   deactivate: ->
     @subs.dispose()
-    @cellhighlighter.deactivate()
 
   consumeInk: (@ink) ->
     @views.ink = @ink

--- a/lib/ui/cellhighlighter.js
+++ b/lib/ui/cellhighlighter.js
@@ -1,7 +1,7 @@
 'use babel'
 
 import { getRange } from '../misc/cells'
-import { CompositeDisposable, Range } from 'atom'
+import { CompositeDisposable } from 'atom'
 import { getLine } from '../misc/blocks.js'
 
 let subs
@@ -33,13 +33,13 @@ export function activate () {
             }))
 
             edSubs.add(ed.onDidDestroy(() => {
-                marker.destroy && marker.destroy()
+                marker && marker.destroy && marker.destroy()
                 borders.forEach(m => m.destroy())
                 edSubs.dispose()
             }))
 
             edSubs.add(ed.onDidChangeGrammar((grammar) => {
-                marker.destroy && marker.destroy()
+                marker && marker.destroy && marker.destroy()
                 borders.forEach(m => m.destroy())
 
                 if (ed.getGrammar().id == 'source.julia') {
@@ -57,13 +57,13 @@ function highlightCurrentCell (ed, marker, borders) {
         return null
     }
 
-    let range = getRange(ed)
+    const range = getRange(ed)
 
     range[1].row +=1
     range[1].column = 0
 
     if (marker && marker.destroy) {
-        let mrange = marker.getBufferRange()
+        const mrange = marker.getBufferRange()
         if (mrange.start.row == range[0].row &&
             mrange.end.row == range[1].row) {
             return marker
@@ -73,7 +73,7 @@ function highlightCurrentCell (ed, marker, borders) {
     }
 
     marker = ed.markBufferRange(range)
-    let decoration = ed.decorateMarker(marker, {
+    ed.decorateMarker(marker, {
         type: 'line',
         class: 'julia-current-cell'
     })
@@ -92,10 +92,10 @@ function highlightCellBorders (ed, borders) {
     borders = []
 
     for (let i = 0; i <= buffer.getEndPosition().row; i++) {
-        let {line, scope} = getLine(ed, i)
+        const { line, scope } = getLine(ed, i)
         if (regex.test(line) && scope.join('.').indexOf('comment.line') > -1) {
             const m = ed.markBufferRange([[i, 0], [i, Infinity]])
-            let decoration = ed.decorateMarker(m, {
+            ed.decorateMarker(m, {
                 type: 'line',
                 class: 'julia-cell-border'
             })


### PR DESCRIPTION
When we switch editors quickly, currently we have small errors around cell highlighting:
```
Uncaught (in promise) TypeError: Cannot read property 'destroy' of null
    at file:///C:/Users/aviat/github/atom-pkgs/atom-julia-client/lib/ui/cellhighlighter.js:36:24
    at wrapped (C:\Users\aviat\AppData\Local\atom\app-1.43.0\resources\app\static\<embedded>:11:1213931)
    at Function.simpleDispatch (C:\Users\aviat\AppData\Local\atom\app-1.43.0\resources\app\static\<embedded>:11:1212922)
    at Emitter.emit (C:\Users\aviat\AppData\Local\atom\app-1.43.0\resources\app\static\<embedded>:11:1214363)
    at TextEditor.destroy (C:\Users\aviat\AppData\Local\atom\app-1.43.0\resources\app\static\<embedded>:11:7180)
    at Pane.destroyItem (C:\Users\aviat\AppData\Local\atom\app-1.43.0\resources\app\static\<embedded>:11:461289)
(anonymous) @ cellhighlighter.js:36
wrapped @ <embedded>:11
simpleDispatch @ <embedded>:11
emit @ <embedded>:11
destroy @ <embedded>:11
destroyItem @ <embedded>:11
```