### PR TITLE
fix block finding

### DIFF
--- a/lib/misc/blocks.js
+++ b/lib/misc/blocks.js
@@ -19,12 +19,15 @@ function isBlank ({line, scope}, allowDocstrings = false) {
   return /^\s*(#.*)?$/.test(line)
 }
 function isEnd ({ line, scope }) {
-  for (const s of scope) {
-    if (/\bstring\.multiline\.end\b/.test(s)) {
-      return true
-    }
+  if (isStringEnd({ line, scope })) {
+    return true
   }
-  return line.match(/^(end\b|\)|\]|\})/)
+  return /^(end\b|\)|\]|\})/.test(line)
+}
+function isStringEnd ({ line, scope }) {
+  scope = scope.join(' ')
+  return /\bstring\.multiline\.end\b/.test(scope) ||
+        (/\bstring\.end\b/.test(scope) && /\bbacktick\b/.test(scope))
 }
 function isCont ({ line, scope }) {
   scope = scope.join(' ')
@@ -56,7 +59,15 @@ function walkForward (ed, start) {
       break
     }
     if (isEnd(lineInfo)) {
-      end = mark
+      // An `end` only counts when  there still are unclosed blocks (indicated by `forLines`
+      // returning a non-empty array).
+      // If the line closes a multiline string we also take that as ending the block.
+      if (
+            !(forLines(ed, start, mark-1).length === 0) ||
+            isStringEnd(lineInfo)
+         ) {
+        end = mark
+      }
     } else if (!(isBlank(lineInfo) || isStart(lineInfo))) {
       end = mark
     }


### PR DESCRIPTION
Fixes both multiline backtick strings and modules:
````
```
kjgkg
```
module Foo
1+1
2+2
3+3
end
````

Regression tests would probably help a lot here, but  ¯\\\_(ツ)\_/¯