### PR TITLE
use object URLs instead of data urls to support objects > 2mb

### DIFF
--- a/lib/runtime/plots.js
+++ b/lib/runtime/plots.js
@@ -17,6 +17,27 @@ function consoleLog (e) {
   log(e.message, `\nat ${e.sourceID}:${e.line}`)
 }
 
+// https://stackoverflow.com/a/5100158/12113178
+function dataURItoBlob (dataURI) {
+  // convert base64/URLEncoded data component to raw binary data held in a string
+  let byteString
+  if (dataURI.split(',')[0].indexOf('base64') >= 0)
+      byteString = atob(dataURI.split(',')[1])
+  else
+      byteString = unescape(dataURI.split(',')[1])
+
+  // separate out the mime component
+  var mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0];
+
+  // write the bytes of the string to a typed array
+  var ia = new Uint8Array(byteString.length)
+  for (var i = 0; i < byteString.length; i++) {
+      ia[i] = byteString.charCodeAt(i)
+  }
+
+  return new Blob([ia], {type:mimeString})
+},
+
 export default {
   activate () {
     client.handle({
@@ -76,14 +97,24 @@ export default {
   },
 
   webview (url) {
+    const isDataURI = url.startsWith('data')
+    if (isDataURI) {
+      const object = dataURItoBlob(url)
+      url = URL.createObjectURL(object)
+    }
+
     const v = views.render(webview({
       class: 'blinkjl',
       src: url,
       style: 'width: 100%; height: 100%'
-    })
-    )
+    }))
     v.classList.add('native-key-bindings')
     v.addEventListener('console-message', e => consoleLog(e))
+    if (isDataURI) {
+      v.addEventListener('dom-ready', e => {
+        URL.revokeObjectURL(url)
+      })
+    }
     return v
   },
 


### PR DESCRIPTION
Fixes https://github.com/JunoLab/Juno.jl/issues/488.

Still problematic for really big objects because the `show` method will take a looong time.