### PR TITLE
fix path error messages on windows

### DIFF
--- a/lib/connection/messages.coffee
+++ b/lib/connection/messages.coffee
@@ -73,15 +73,8 @@ module.exports =
         """
         We tried to launch Julia from: `#{path}`
         This path can be changed in the settings.
-        """ + if details isnt ''
-          """
-
-          Details:
-
-              #{details}
-          """
-        else
-          ""
+        """
+      detail: details
       dismissable: true
 
   connectExternal: ->

--- a/lib/connection/process/basic.js
+++ b/lib/connection/process/basic.js
@@ -4,6 +4,7 @@ import tcp from './tcp'
 import * as pty from 'node-pty-prebuilt-multiarch'
 import net from 'net'
 import { paths, mutex } from '../../misc'
+import { jlNotFound } from '../messages'
 
 export var lock = mutex()
 
@@ -111,6 +112,7 @@ function getProcess (path, args, env) {
           reject(err)
         })
       }).catch((err) => {
+        jlNotFound(path, err)
         reject(err)
       })
     }).catch((err) => {

--- a/lib/misc/paths.coffee
+++ b/lib/misc/paths.coffee
@@ -21,6 +21,11 @@ module.exports =
     new Promise (resolve, reject) ->
       if fs.existsSync(path) then resolve(path)
 
+      if process.platform is 'win32'
+        if /[a-zA-Z]\:/.test(path)
+          reject("Couldn't resolve path.")
+          return
+
       which = if process.platform is 'win32' then 'where' else 'which'
       proc = child_process.exec "#{which} \"#{path}\"", (err, stdout, stderr) ->
         return reject(stderr) if err?


### PR DESCRIPTION
Turns out that Windows' `where` can't deal with full paths, so this introduces a special case for absolute paths on windows.