### PR TITLE
improve outline subscriptions

### DIFF
--- a/lib/runtime/outline.js
+++ b/lib/runtime/outline.js
@@ -1,119 +1,117 @@
 'use babel'
 
-import { CompositeDisposable } from 'atom'
+import { CompositeDisposable, Disposable, TextEditor } from 'atom'
 import { throttle } from 'underscore-plus'
 import { client } from '../connection'
 import modules from './modules'
 
 const updateeditor = client.import('updateeditor')
-let pane, subs
+let pane, subs, edSubs, outline
 
 export function activate (ink) {
   pane = ink.Outline.fromId('Julia-Outline')
   subs = new CompositeDisposable()
+  edSubs = new CompositeDisposable()
+  outline = []
 
-  subs.add(atom.config.observe('julia-client.uiOptions.layouts.outline.defaultLocation', (defaultLocation) => {
-    pane.setDefaultLocation(defaultLocation)
-  }))
-  subs.add(client.onDetached(() => pane.setItems([])))
-
-  let edSubs = new CompositeDisposable()
-  subs.add(atom.workspace.onDidChangeActiveTextEditor(throttle(ed => {
-    if (!ed) return
-
-    edSubs.dispose()
-
-    if (ed.getGrammar().id !== 'source.julia') {
+  subs.add(
+    atom.config.observe('julia-client.uiOptions.layouts.outline.defaultLocation', defaultLocation => {
+      pane.setDefaultLocation(defaultLocation)
+    }),
+    atom.workspace.onDidStopChangingActivePaneItem(throttle(ed => watchEditor(ed), 300)),
+    atom.packages.onDidActivateInitialPackages(() => watchEditor(atom.workspace.getActivePaneItem())),
+    client.onDetached(() => {
+      outline = []
       pane.setItems([])
-      return
-    }
-
-    edSubs = new CompositeDisposable()
-
-    edSubs.add(ed.onDidDestroy(() => {
-      edSubs.dispose()
+    }),
+    new Disposable(() => {
+      outline = []
       pane.setItems([])
-    }))
-    edSubs.add(ed.onDidChangeGrammar((grammar) => {
-      if (grammar.id !== 'source.julia') {
-        edSubs.dispose()
-        pane.setItems([])
-      }
-    }))
-
-    let outline = []
-
-    edSubs.add(ed.onDidStopChanging(() => {
-      updateEditor(ed).then(outlineItems => {
-        outline = handleOutline(ed, edSubs, outlineItems)
-      }).catch(err => {
-        console.log(err);
-      })
-    }))
-
-    edSubs.add(ed.onDidChangeCursorPosition(throttle(() => {
-      const cursorLine = ed.getCursorBufferPosition().row + 1
-
-      outline = outline.map(item => {
-        item.isActive = item.start <= cursorLine && cursorLine <= item.stop
-        return item
-      })
-
-      pane.setItems(outline)
-    }, 300)))
-
-    updateEditor(ed, {
-      updateSymbols: false
-    }).then(outlineItems => {
-      outline = handleOutline(ed, edSubs, outlineItems)
-    }).catch(err => {
-      console.log(err);
+      if (edSubs) edSubs.dispose()
     })
-  }, 300)))
+  )
+}
+
+function watchEditor (ed) {
+  if (!(ed && ed instanceof TextEditor)) return
+
+  if (edSubs) edSubs.dispose()
+  edSubs = new CompositeDisposable() // we can't repeat disposing on the same `CompositeDisposable` object
+
+  if (ed.getGrammar().id !== 'source.julia') {
+    pane.setItems([])
+  } else {
+    edSubs.add(
+      ed.onDidStopChanging(throttle(() => updateEditor(ed), 300)),
+      ed.onDidChangeCursorPosition(throttle(() => updateOutline(ed), 300))
+    )
+    updateEditor(ed, { updateSymbols: false })
+  }
+  edSubs.add(
+    ed.onDidDestroy(() => {
+      outline = []
+      pane.setItems([])
+    }),
+    ed.onDidChangeGrammar(grammar => {
+      watchEditor(ed)
+    })
+  )
 }
 
 // NOTE: update outline and symbols cache all in one go
-function updateEditor (editor, options = {
+function updateEditor (ed, options = {
   updateSymbols: true
 }) {
-  if (!client.isActive()) {
-    return new Promise((resolve) => resolve([]))
-  }
+  if (!client.isActive()) return new Promise(resolve => resolve([]))
 
-  const text = editor.getText()
+  const text = ed.getText()
   const currentModule = modules.current()
   const mod = currentModule ? currentModule : 'Main'
-  const path = editor.getPath() || 'untitled-' + editor.getBuffer().getId()
-  return updateeditor({
+  const path = ed.getPath() || 'untitled-' + ed.getBuffer().getId()
+
+  updateeditor({
     text,
     mod,
     path,
     // https://github.com/JunoLab/Juno.jl/issues/407
     updateSymbols: options.updateSymbols
+  }).then(outlineItems => {
+    outline = handleOutline(ed, outlineItems)
+  }).catch(err => {
+    console.log(err);
   })
 }
 
-function handleOutline (ed, subs, items) {
+function handleOutline (ed, outlineItems) {
   const cursorLine = ed.getCursorBufferPosition().row + 1
 
-  items = items.map(item => {
-    item.isActive = item.start <= cursorLine && cursorLine <= item.stop
-    item.onClick = () => {
+  outlineItems = outlineItems.map(outlineItem => {
+    outlineItem.isActive = outlineItem.start <= cursorLine && cursorLine <= outlineItem.stop
+    outlineItem.onClick = () => {
       for (const pane of atom.workspace.getPanes()) {
         if (pane.getItems().includes(ed)) {
           pane.activate()
           pane.setActiveItem(ed)
-          ed.setCursorBufferPosition([item.start - 1, 0])
+          ed.setCursorBufferPosition([outlineItem.start - 1, 0])
           ed.scrollToCursorPosition()
           break
         }
       }
     }
-    return item
+    return outlineItem
   })
 
-  pane.setItems(items)
-  return items
+  pane.setItems(outlineItems)
+  return outlineItems
+}
+
+function updateOutline (ed) {
+  const cursorLine = ed.getCursorBufferPosition().row + 1
+  outline = outline.map(item => {
+    item.isActive = item.start <= cursorLine && cursorLine <= item.stop
+    return item
+  })
+  pane.setItems(outline)
 }
 
 export function open () {
@@ -127,5 +125,5 @@ export function close () {
 }
 
 export function deactivate () {
-  subs.dispose()
+  if (subs) subs.dispose()
 }


### PR DESCRIPTION
- use `onDidStopChangingActivePaneItem` API instead of 
`onDidChangeActiveTextEditor` for more throttled works
- handle grammar change correctly (non-julia to julia pass)
- handle initially opened editor correctly
- more disposing (while keeping them safe)