### PR TITLE
Better default for cell delimiters

### DIFF
--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -311,7 +311,7 @@ config =
       cellDelimiter:
         title: 'Cell Delimiter'
         type: 'array'
-        default: ['##', '#---', '#%%', '# %%']
+        default: ['##\\s', '#---', '#%%', '# %%']
         description: 'Regular expressions for determining cell delimiters.'
         order: 11
       highlightCells:

--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -311,7 +311,7 @@ config =
       cellDelimiter:
         title: 'Cell Delimiter'
         type: 'array'
-        default: ['##\\s', '#---', '#%%', '# %%']
+        default: ['##\\s', '#---', '#\\s?%%']
         description: 'Regular expressions for determining cell delimiters.'
         order: 11
       highlightCells:


### PR DESCRIPTION
Some style guides (such as [YASGuide](https://github.com/jrevels/YASGuide)) recommend using the following section headers:

```
#####
##### Section Name
#####
```

This conflicts with the default cell delimiters regexps of Juno, which would create three cells when seeing the header above.

**Proposed fix:** replace the `##` regexp by `##\s`, as suggested by @pfitzseb on Slack.

Signed-off-by: Jonathan Laurent <jonathan.laurent@cs.cmu.edu>