### PR TITLE
release note

### DIFF
--- a/lib/package/config.coffee
+++ b/lib/package/config.coffee
@@ -688,6 +688,11 @@ config =
     default: true
     order: 99
 
+  currentVersion:
+    type: 'string'
+    default: '0.0.0'
+    order: 100
+
 if process.platform != 'darwin'
   config.consoleOptions.properties.whitelistedKeybindingsREPL.default =
     ['Ctrl-C', 'Ctrl-J', 'Ctrl-K', 'Ctrl-E', 'Ctrl-V', 'Ctrl-M', 'F5', 'F8', 'F9',

--- a/lib/package/menu.coffee
+++ b/lib/package/menu.coffee
@@ -98,6 +98,7 @@ module.exports =
       {type: 'separator'}
 
       {label: 'Debug Information', command: 'julia-client:debug-info'}
+      {label: 'Release Note...', command: 'julia-client:open-release-note'}
       {label: 'Help...', command: 'julia:get-help'}
       {label: 'Settings...', command: 'julia-client:settings'}
     ]

--- a/lib/package/release-note.js
+++ b/lib/package/release-note.js
@@ -1,0 +1,41 @@
+/** @babel */
+
+import { CompositeDisposable } from 'atom'
+import path from 'path'
+import fs from 'fs'
+import { show } from '../ui/selector'
+import { readCode } from '../misc/paths'
+
+let startupNoteVersion, subs
+const RELEASE_NOTE_DIR = path.join(__dirname, '..', '..', 'release-notes')
+
+export function activate (ink) {
+  const pane = ink.NotePane.fromId('Note')
+  const showNote = (version) => {
+    const p = path.join(RELEASE_NOTE_DIR, version + '.md')
+    const markdown = readCode(p)
+    pane.setNote(markdown)
+    pane.setTitle(`Juno release note – v${version}`)
+    pane.ensureVisible()
+  }
+  subs = new CompositeDisposable()
+  subs.add(
+    atom.commands.add('atom-workspace',  'julia-client:open-release-note', () => {
+      const versions = fs.readdirSync(RELEASE_NOTE_DIR)
+        .filter(path => path !== 'README.md')
+        .map(path => path.replace(/(.+)\.md/, 'v $1'))
+      show(versions)
+        .then(version => showNote(version.replace(/v\s(.+)/, '$1')))
+        .catch(err => console.log(err))
+    })
+  )
+  if (startupNoteVersion) showNote(startupNoteVersion)
+}
+
+export function showStartupNote (version) {
+  startupNoteVersion = version
+}
+
+export function deactivate () {
+  if (subs) subs.dispose()
+}

--- a/release-notes/0.12.0.md
+++ b/release-notes/0.12.0.md
@@ -1,0 +1,110 @@
+Hi all,
+
+Juno 0.12 is out !
+Since we have ***tons*** of bugfixes and improvements for this release, here I'm going to pick some of the key highlights, but we hope you will like all the improvements and features added :)
+
+
+## Release notes
+
+### New features
+
+- Juno is now able to debug toplevel code, i.e. you don't need type `Juno.@enter` in REPL anymore ! ([Atom.jl#269](https://github.com/JunoLab/Atom.jl/pull/269), [atom-julia-client#683](https://github.com/JunoLab/atom-julia-client/pull/683), [atom-ink#255](https://github.com/JunoLab/atom-ink/pull/255), [atom-ink#256](https://github.com/JunoLab/atom-ink/pull/256))
+  * You can use `Julia Debug: Run File (Block, Cell)` and `Julia Debug: Step Through File (Block, Cell)` commands (or corresponding menus) for debugging whole `.jl` file, selected code block, or even a Weave code cell, etc.
+  * (showcase) Debugging toplevel code demo: ![toplevel code debugging](https://aws1.discourse-cdn.com/business5/uploads/julialang/original/2X/a/a16f97c17617e7fa383ff9bbb400b1f56ec7ca29.gif)
+- QoL improvements on profiler ([Atom.jl#244](https://github.com/JunoLab/Atom.jl/pull/244), [Juno.jl#463](https://github.com/JunoLab/Juno.jl/pull/463), [atom-julia-client#672](https://github.com/JunoLab/atom-julia-client/pull/672), [atom-ink#247](https://github.com/JunoLab/atom-ink/pull/247) – we internally use [FlameGraphs.jl](https://github.com/timholy/FlameGraphs.jl), thanks @tim.holy for suggesting this collaboration !):
+  * Lines where dynamic dispatch or garbage collection happened are specially colored (yellow and red, respectively) so that we can find performance pitfalls more easily
+  * Prunes stacktraces that relate to Juno's internal tasks by default
+  * Fixed incorrect inline highlight lengths
+  * Keyword option control for `@profiler` macro
+  * (showcase) New profiler look example: ![Profiling example](https://aws1.discourse-cdn.com/business5/uploads/julialang/original/2X/2/262d39906c119347536d16c6decdb872080d9cad.png)
+- Provides smoother ways to run/debug a file from tree-view. You can use `Julia Client: Run File`, `Julia Debug: Run File` and `Julia Debug: Run File` commands and the corresponding menus within tree-view ([atom-julia-client#684](https://github.com/JunoLab/atom-julia-client/pull/684))
+  * (showcase) New tree-view menus look: ![tree-view-menus](https://aws1.discourse-cdn.com/business5/uploads/julialang/original/2X/e/eea9a223a2f27388b4824e01f0b77cd11af9f468.png)
+- [Additional formatting options for JuliaFormatter.jl](https://domluna.github.io/JuliaFormatter.jl/dev/#Formatting-Options-1) can be specified via `Julia Options ⟶ Formating Options` config setting ([atom-julia-client#682](https://github.com/JunoLab/atom-julia-client/pull/682), [Atom.jl#259](https://github.com/JunoLab/Atom.jl/pull/259))
+- Added the `Julia Options ⟶ Format the current editor when saving` config option ([atom-julia-client#677](https://github.com/JunoLab/atom-julia-client/pull/677))
+- Code cells are highlighted, and cell detection logic gets improved ([atom-julia-client#674](https://github.com/JunoLab/atom-julia-client/pull/674), [atom-julia-client#675](https://github.com/JunoLab/atom-julia-client/pull/675))
+  * If you don't like this, head for `UI Options ⟶ Highlight Cells` setting
+- The new command `Julia Client: Activate Enviroment In Parent Folder` (or `Juno ⟶ Enviroment ⟶ Enviroment in Parent Folder` menu) automatically searches a `Project.toml` file up from the current file's directory and then activate it if exist ([Atom.jl#241](https://github.com/JunoLab/Atom.jl/pull/241), [atom-julia-client#670](https://github.com/JunoLab/atom-julia-client/pull/670))
+- A terminal instance can be started from the current editor directory via `Julia Client: New Terminal From Current Folder` command (or `Juno ⟶ New Terminal ⟶ Current File's Folder` menu) ([atom-julia-client#657](https://github.com/JunoLab/atom-julia-client/pull/657))
+
+### Improvements
+
+- Juno's REPL and terminal now use [WebGL renderer for xtermjs](https://github.com/xtermjs/xterm.js/pull/1790) by default, which should bring us a vast improvement for rendering-performance ([atom-ink#242](https://github.com/JunoLab/atom-ink/pull/242), [atom-julia-client#660](https://github.com/JunoLab/atom-julia-client/pull/660))
+- LOTS of improvements around static analysis features (used for `Julia Client: Open Outline Pane`, `Julia Client: Goto Symbol` or clicking a name in the workspace view, etc.)
+  * Modules are more correctly detected ([Atom.jl#215](https://github.com/JunoLab/Atom.jl/pull/215))
+  * More memory efficient symbols cache ([Atom.jl#219](https://github.com/JunoLab/Atom.jl/pull/219))
+  * Escape possible danger with recursive `include` loops ([Atom.jl#256](https://github.com/JunoLab/Atom.jl/pull/256))
+  * Update to the latest version of [CSTParser.jl](https://github.com/julia-vscode/CSTParser.jl) ([Atom.jl#262](https://github.com/JunoLab/Atom.jl/pull/262))
+  * Show local binding verbatim in completions ([Atom.jl#275](https://github.com/JunoLab/Atom.jl/pull/275))
+  * ... and much more ([atom-julia-client#643](https://github.com/JunoLab/atom-julia-client/pull/643), [Atom.jl#205](https://github.com/JunoLab/Atom.jl/pull/205), [Atom.jl#206](https://github.com/JunoLab/Atom.jl/pull/206), [Atom.jl#208](https://github.com/JunoLab/Atom.jl/pull/208), [atom-julia-client#651](https://github.com/JunoLab/atom-julia-client/pull/651), [Atom.jl#220](https://github.com/JunoLab/Atom.jl/pull/220), [Atom.jl#221](https://github.com/JunoLab/Atom.jl/pull/221), [Atom.jl#268](https://github.com/JunoLab/Atom.jl/pull/268), [Atom.jl#272](https://github.com/JunoLab/Atom.jl/pull/272), [Atom.jl#273](https://github.com/JunoLab/Atom.jl/pull/273))
+- Performance improvements around Juno's GUI rendering:
+  * Improved result animation ([atom-ink#244](https://github.com/JunoLab/atom-ink/pull/244))
+  * Fixed idle CPU usage with plot open ([atom-ink#248](https://github.com/JunoLab/atom-ink/pull/248))
+- Improved mouse clicking behavior on inline results ([atom-ink#239](https://github.com/JunoLab/atom-ink/pull/239/files))
+  * Now clicking an inline result with middle-mouse button will clear it
+  * Fixed text selecting
+- Auto completion feature gets enhanced sooooo much:
+  * General performance improvements ([Atom.jl#234](https://github.com/JunoLab/Atom.jl/pull/234))
+  * Method completions now infer their return types using the current input argument types ([Atom.jl#276](https://github.com/JunoLab/Atom.jl/pull/276))
+  * Lazy return type inference and result caching ([Atom.jl#278](https://github.com/JunoLab/Atom.jl/pull/278))
+  * (showcase) Moar return type inference example: ![Inference example](https://aws1.discourse-cdn.com/business5/uploads/julialang/original/2X/0/045e20f86dedc3a14bd58a3d1cb51c8c1c6fe566.png)
+- Start to support more extensive precompilations (using [SnoopCompile.jl](https://github.com/timholy/SnoopCompile.jl)), which hopefully gives better first-time invocation speed for various features ([Atom.jl#270](https://github.com/JunoLab/Atom.jl/pull/270), [Juno.jl#476](https://github.com/JunoLab/Juno.jl/pull/476) – thanks @Amin_Yahyaabadi for taking the initiative on this !)
+- Better documentation search ([DocSeeker.jl#17](https://github.com/JunoLab/DocSeeker.jl/pull/17), [Atom.jl#232](https://github.com/JunoLab/Atom.jl/pull/232), [DocSeeker.jl#19](https://github.com/JunoLab/DocSeeker.jl/pull/19))
+- Clicking links in a REPL/terminal now needs `ctrl/cmd` modifier as in-editor symbol jump and prevents "random clicking on terminal" from opening a file ([atom-ink#251](https://github.com/JunoLab/atom-ink/pull/251), [atom-julia-client#678](https://github.com/JunoLab/atom-julia-client/pull/678))
+  * If you don't like this change, you can restore the previous behavior by turning off the `Julia Client > Terminal Options > Ctrl/Cmd modifier for link activation` config setting:
+
+### Bugfixes
+
+- Cover edge cases in code block finding logic ([atom-julia-client#661](https://github.com/JunoLab/atom-julia-client/pull/661))
+- Fixed issues around menus ([atom-julia-client#671](https://github.com/JunoLab/atom-julia-client/pull/671))
+- Debug prompt now can accept multi-line expression ([Atom.jl#273](https://github.com/JunoLab/Atom.jl/pull/273))
+- Fixed focusing behavior with mouse hovering on inline results ([atom-ink#245](https://github.com/JunoLab/atom-ink/pull/245))
+
+
+## Installation
+
+### Atom packages
+
+***Important : To fully update Atom packages, you need to restart all the previous Atom processes***
+
+Install the latest versions of `julia-client` and `ink` packages:
+Close all the Atom windows and type the following command into your terminal:
+```
+apm update
+```
+
+If that also doesn’t work (or if you want to only update Juno packages), try the commands below instead:
+```
+apm uninstall ink
+apm uninstall julia-client
+apm install ink
+apm install julia-client
+```
+
+### Julia packages
+
+Execute the following in a Julia prompt:
+
+```julia
+pkg> up Atom Juno
+```
+
+### Versions
+
+***Important*** : This release *requires* Atom 1.39, 1.40.1, or higher.
+
+As always, make sure all Julia and Atom packages are up-to-date.
+
+Julia packages:
+
+* Atom.jl version: 0.12.8
+* Juno.jl version: 0.8.1
+
+Atom packages:
+
+* julia-client version: 0.12.3
+* ink version: 0.12.3
+
+
+That's all, thanks !
+
+[Shuhei](https://github.com/aviatesk) and [Sebastian](https://github.com/pfitzseb),

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -1,0 +1,15 @@
+# Juno – release notes
+
+This folder contains release notes of Juno.
+Those notes are also posted as [Julia Discourse](https://discourse.julialang.org/c/tools/juno).
+
+The release notes will be automatically opened when an user has updated this package
+and the updated version has a release note.
+Also we can manually view a release note via `julia-client: open-release-note` command.
+
+
+## Developer notes
+
+- in order for those features to work properly, release notes must be named under the rule: `major.minor.patch.md`
+- markdowns are parsed and transformed into HTML by [marked](https://marked.js.org/#/README.md) npm package
+- URLs should already exist somewhere; e.g. we should replace "upload://" when we use Discourse's image upload feature


### PR DESCRIPTION
closes https://github.com/JunoLab/Juno.jl/issues/545
needs https://github.com/JunoLab/atom-ink/pull/270

workflow:
- upload images somewhere (GitHub, Discourse etc) -> write markdown -> publish it here and on discourse

when release note pop up:
- when an user update this package from the previous minor version => show the latest minor version release note
- when an user update from the current minor verison => show the latest patch version release note