### PR TITLE
just use julia-client's selector

### DIFF
--- a/lib/runtime/goto.js
+++ b/lib/runtime/goto.js
@@ -14,6 +14,7 @@ import {
   isValidWordToInspect
 } from '../misc/words'
 import { getLocalContext } from '../misc/blocks'
+import { show } from '../ui/selector'
 
 const {
   gotosymbol: gotoSymbol,
@@ -68,6 +69,28 @@ class Goto {
     return client.isActive() && this.ink !== undefined
   }
 
+  // TODO: handle remote files ?
+  selectItemsAndGo (items) {
+    if (items.length === 0) return
+    if (items.length === 1) {
+      const item = items[0]
+      return this.ink.Opener.open(item.file, item.line, {
+        pending: atom.config.get('core.allowPendingPaneItems')
+      })
+    }
+    items = items.map(result => {
+      result.primary = result.text
+      result.secondary = `${result.file}:${result.line}`
+      return result
+    })
+    return show(items).then(item => {
+      if (!item) return
+      this.ink.Opener.open(item.file, item.line, {
+        pending: atom.config.get('core.allowPendingPaneItems')
+      })
+    })
+  }
+
   gotoSymbol () {
     const editor = atom.workspace.getActiveTextEditor()
     const bufferPosition = editor.getCursorBufferPosition()
@@ -76,9 +99,8 @@ class Goto {
     const rangeFilePath = this.getJumpFilePath(editor, bufferPosition)
     if (rangeFilePath) {
       const { filePath } = rangeFilePath
-      return atom.workspace.open(filePath, {
+      return this.ink.Opener.open(filePath, 0, {
         pending: atom.config.get('core.allowPendingPaneItems'),
-        searchAllPanes: true
       })
     }
 
@@ -103,7 +125,7 @@ class Goto {
     const mod = currentModule ? currentModule : 'Main'
     const text = editor.getText() // buffer text that will be used for fallback entry
 
-    gotoSymbol({
+    return gotoSymbol({
       word,
       path: editor.getPath() || 'untitled-' + editor.getBuffer().getId(),
       // local context
@@ -117,9 +139,7 @@ class Goto {
       text
     }).then(results => {
       if (results.error) return
-      this.ink.goto.goto(results, {
-        pending: atom.config.get('core.allowPendingPaneItems')
-      })
+      this.selectItemsAndGo(results.items)
     }).catch(err => {
       console.log(err)
     })
@@ -134,9 +154,8 @@ class Goto {
         return {
           range,
           callback: () => {
-            atom.workspace.open(filePath, {
+            return this.ink.Opener.open(filePath, 0, {
               pending: atom.config.get('core.allowPendingPaneItems'),
-              searchAllPanes: true
             })
           }
         }
@@ -190,13 +209,7 @@ class Goto {
           }
           resolve({
             range,
-            callback: () => {
-              setTimeout(() => {
-                this.ink.goto.goto(results, {
-                  pending: atom.config.get('core.allowPendingPaneItems')
-                })
-              }, 5)
-            }
+            callback: () => setTimeout(() => this.selectItemsAndGo(results.items), 5)
           })
         }).catch(err => {
           console.log(err)

--- a/lib/runtime/workspace.coffee
+++ b/lib/runtime/workspace.coffee
@@ -1,8 +1,8 @@
 {CompositeDisposable} = require 'atom'
 
-{views} = require '../ui'
 {client} = require '../connection'
-
+{views} = require '../ui'
+goto = require './goto'
 modules = require './modules'
 
 { workspace, gotosymbol: gotoSymbol, clearLazy } = client.import rpc: ['workspace', 'gotosymbol'], msg: 'clearLazy'
@@ -42,10 +42,9 @@ module.exports =
       gotoSymbol
         word: name,
         mod: mod
-      .then (symbols) =>
-        return if symbols.error
-        @ink.goto.goto symbols,
-          pending: atom.config.get('core.allowPendingPaneItems')
+      .then (results) =>
+        return if results.error
+        goto.selectItemsAndGo(results.items)
 
   create: ->
     @ws = @ink.Workspace.fromId 'julia'

--- a/lib/ui/docs.js
+++ b/lib/ui/docs.js
@@ -1,8 +1,9 @@
 'use babel'
 
-import { client } from '../connection'
 import { CompositeDisposable } from 'atom'
+import { client } from '../connection'
 const views = require('./views')
+import goto from '../runtime/goto'
 
 const {
   searchdocs: searchDocs,
@@ -74,11 +75,9 @@ export function processItem (item) {
     gotoSymbol({
       word: item.name,
       mod: item.mod
-    }).then(symbols => {
-      if (symbols.error) return
-      ink.goto.goto(symbols, {
-        pending: atom.config.get('core.allowPendingPaneItems')
-      })
+    }).then(results => {
+      if (results.error) return
+      return goto.selectItemsAndGo(results.items)
     })
   }
 


### PR DESCRIPTION
So we don't need `ink.goto` anymore.
Corresponds to https://github.com/JunoLab/atom-ink/pull/271