### PR TITLE
To Correctly Handle links for shortened-paths introduced in the updated stacktrace of Julia 1.6.0

### DIFF
--- a/lib/runtime/console.js
+++ b/lib/runtime/console.js
@@ -248,6 +248,9 @@ function hasKeyboardModifier (event) {
 function handleLink (event, uri) {
   if (!hasKeyboardModifier(event)) return false
 
+  // To handle links to new stacktrace shortened paths introduced in Julia 1.6.0
+  uri = uri.replace(/\B([/\\]?~[/\\])/,require('os').homedir().concat("/"))
+
   if (client.isActive()) {
     fullpath(uri).then(([path, line]) => {
       ink.Opener.open(path, line - 1, {


### PR DESCRIPTION
This fix will correctly handle links for shortened-paths introduced in the updated stacktrace of Julia 1.6.0, so clicking on a shortened-path in the new stacktrace should take you to the correct code position.

This is done by expanding the tilde "~" symbol to be the home directory in the link only (will not change the actual path on screen in the stacktrace).

This is tested on a Windows 10 machine, but it should work for MacOs and Linux as well (confirmation would be appreciated).